### PR TITLE
Clarify batch availability in together-batch-inference skill

### DIFF
--- a/skills/together-batch-inference/references/api-reference.md
+++ b/skills/together-batch-inference/references/api-reference.md
@@ -240,7 +240,17 @@ curl -X GET "https://api.together.xyz/v1/batches" \
 
 - `meta-llama/Llama-3.3-70B-Instruct-Turbo`
 
-Most serverless models support batch processing through the chat completions endpoint; models not listed above have no discount. A small number of serverless models are not available for batch and will fail if submitted, currently `deepseek-ai/DeepSeek-R1-0528-tput` and `deepseek-ai/DeepSeek-V3.1`.
+Most serverless models support batch processing through the chat completions endpoint; models not listed above have no discount. The following serverless models are not currently available for batch and will fail if submitted:
+
+- `deepseek-ai/DeepSeek-R1`
+- `deepseek-ai/DeepSeek-V3.1`
+- `deepseek-ai/DeepSeek-V4-Pro`
+- `MiniMaxAI/MiniMax-M2.7`
+- `moonshotai/Kimi-K2.5`
+- `moonshotai/Kimi-K2.6`
+- `Qwen/Qwen3.5-397B-A17B`
+- `zai-org/GLM-5`
+- `zai-org/GLM-5.1`
 
 ## Rate Limits
 

--- a/skills/together-batch-inference/references/api-reference.md
+++ b/skills/together-batch-inference/references/api-reference.md
@@ -245,7 +245,7 @@ curl -X GET "https://api.together.xyz/v1/batches" \
 - `zai-org/GLM-4.5-Air-FP8`
 - `openai/whisper-large-v3`
 
-All serverless models support batch processing — models not listed have no discount.
+Most serverless models support batch processing through the chat completions endpoint; models not listed above have no discount. A small number of serverless models are not available for batch and will fail if submitted, currently `deepseek-ai/DeepSeek-R1-0528-tput` and `deepseek-ai/DeepSeek-V3.1`.
 
 ## Rate Limits
 


### PR DESCRIPTION
## Summary

- Mirrors the docs fix in [mintlify-docs#782](https://github.com/togethercomputer/mintlify-docs/pull/782).
- Replaces the inaccurate "All serverless models support batch processing" claim in `skills/together-batch-inference/references/api-reference.md` with a more accurate version that flags the small set of currently-unavailable models.

Linear: [MLE-5279](https://linear.app/together-ai/issue/MLE-5279/update-batch-docs-for-models-not-available)

## Test plan

- [ ] Read the rendered skill reference and confirm the batch-availability paragraph reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)