### PR TITLE
DX-596-together-fine-tuning: sync with mintlify-docs#870

### DIFF
--- a/skills/together-fine-tuning/SKILL.md
+++ b/skills/together-fine-tuning/SKILL.md
@@ -57,7 +57,7 @@ Supported workflows in this repo:
 2. Validate dataset format before spending tokens on training.
 3. Upload training data and keep the returned file ID.
 4. Create the job with explicit method-specific parameters.
-5. Monitor job state, events, and checkpoints before handing off to deployment.
+5. Monitor job state, events, checkpoints, and per-step training metrics before handing off to deployment.
 
 ## High-Signal Rules
 

--- a/skills/together-fine-tuning/references/deployment.md
+++ b/skills/together-fine-tuning/references/deployment.md
@@ -153,7 +153,24 @@ for event in events.data:
 checkpoints = client.fine_tuning.list_checkpoints(id=job_id)
 for cp in checkpoints:
     print(f"Step {cp.step}: {cp.metrics}")
+
+# List per-step training metrics (loss, learning rate, grad norm, eval/loss, ...)
+metrics = client.fine_tuning.list_metrics(job_id)
+for step in metrics.metrics:
+    print(step)
 ```
+
+`list_metrics` accepts optional filters for trimming long runs:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `global_step_from` | int | Return only metrics with `global_step` >= this value |
+| `global_step_to` | int | Return only metrics with `global_step` <= this value |
+| `logged_at_from` | str or datetime | Return only metrics logged at or after this ISO 8601 timestamp |
+| `logged_at_to` | str or datetime | Return only metrics logged at or before this ISO 8601 timestamp |
+| `resolution` | int | Cap the response at this many uniformly sampled training points (eval metrics are always returned in full) |
+
+Each entry is either a training step (`train/global_step`, `train/loss`, `train/learning_rate`, `train/grad_norm`, ...) or an eval step (`eval/loss`, ...). When both occur at the same step, two separate objects are returned.
 
 ### CLI
 
@@ -161,10 +178,14 @@ for cp in checkpoints:
 together fine-tuning retrieve <JOB_ID>
 together fine-tuning list-events <JOB_ID>
 together fine-tuning list-checkpoints <JOB_ID>
+together fine-tuning list-metrics <JOB_ID>            # ASCII charts (default)
+together fine-tuning list-metrics <JOB_ID> --json     # raw JSON output
 together fine-tuning list
 together fine-tuning cancel <JOB_ID>
 together fine-tuning delete <JOB_ID>
 ```
+
+`list-metrics` also accepts `--global-step-from`, `--global-step-to`, `--logged-at-from`, `--logged-at-to`, and `--resolution` for the same filtering behavior as the Python SDK.
 
 ### cURL
 


### PR DESCRIPTION
Syncs the `together-fine-tuning` skill with [togethercomputer/mintlify-docs#870](https://github.com/togethercomputer/mintlify-docs/pull/870) ("MOSH-2701: Metrics documentation").

### Docs that triggered this sync
- `docs/fine-tuning-training-metrics.mdx` (new page)
- `docs/fine-tuning-quickstart.mdx` (added cross-link bullet to the new metrics page)

### Skill changes
- `references/deployment.md` — under **Job Monitoring**, added a Python snippet for `client.fine_tuning.list_metrics(job_id)` and a parameter table covering `global_step_from`, `global_step_to`, `logged_at_from`, `logged_at_to`, and `resolution`.
- `references/deployment.md` — added the new `together fine-tuning list-metrics <JOB_ID>` CLI lines (default ASCII charts and `--json`) plus a note on the matching CLI flags.
- `SKILL.md` — workflow step 5 now mentions "per-step training metrics" alongside state, events, and checkpoints.

Validated with `scripts/quick_validate.py` and `scripts/quality_check.py`.

---
Generated by the Sync Skills Cursor Automation. Please review before merging.