### PR TITLE
DX-596-together-audio: sync with mintlify-docs#874

### DIFF
--- a/skills/together-audio/references/tts-models.md
+++ b/skills/together-audio/references/tts-models.md
@@ -27,6 +27,7 @@ These models are current in the latest text-to-speech guide and are not listed i
 | Rime Arcana v2 | `rime-labs/rime-arcana-v2` | Dedicated / Reserved | REST, Streaming, WebSocket | Dedicated only |
 | Rime Mist v3 (Beta) | `rime-labs/rime-mist-v3` | Dedicated / Reserved | REST, Streaming, WebSocket | Dedicated only |
 | Rime Mist v2 | `rime-labs/rime-mist-v2` | Dedicated / Reserved | REST, Streaming, WebSocket | Dedicated only |
+| MiniMax Speech 2.8 Turbo | `minimax/speech-2.8-turbo` | Dedicated / Reserved | REST, Streaming, WebSocket | Dedicated only |
 | MiniMax Speech 2.6 Turbo | `minimax/speech-2.6-turbo` | Dedicated / Reserved | REST, Streaming, WebSocket | Dedicated only |
 
 Notes:
@@ -219,3 +220,8 @@ Regional examples include:
 
 `English_DeterminedMan`, `English_Diligent_Man`, `English_expressive_narrator`,
 `English_FriendlyNeighbor`, `English_Graceful_Lady`, `Japanese_GentleButler`
+
+### MiniMax Speech 2.8 Turbo
+
+`English_CalmWoman`, `English_CaptivatingStoryteller`, `English_CharmingQueen`,
+`English_Comedian`, `English_ConfidentWoman`, `English_Cute_Girl`


### PR DESCRIPTION
Sync `together-audio` with merged docs PR togethercomputer/mintlify-docs#874.

**Changed docs files that triggered this:**
- `docs/inference/text-to-speech/overview.mdx`

**Skill changes:**
- Add a `MiniMax Speech 2.8 Turbo` row to the Model Catalog table in `skills/together-audio/references/tts-models.md` (API string `minimax/speech-2.8-turbo`, Dedicated / Reserved access, REST + Streaming + WebSocket endpoints), mirroring the existing 2.6 Turbo entry.
- Add a new `### MiniMax Speech 2.8 Turbo` section under `Voice Lists` with the six sample voices documented in the merged doc: `English_CalmWoman`, `English_CaptivatingStoryteller`, `English_CharmingQueen`, `English_Comedian`, `English_ConfidentWoman`, `English_Cute_Girl`.

Generated by the Sync Skills Cursor Automation. Please review before merging.
