### PR TITLE
DX-596-together-evaluations: sync with mintlify-docs#871

### DIFF
--- a/skills/together-evaluations/references/api-reference.md
+++ b/skills/together-evaluations/references/api-reference.md
@@ -71,6 +71,9 @@ Authentication: `Authorization: Bearer $TOGETHER_API_KEY`
 | `input_data_file_path` | string | Yes | Uploaded dataset file ID |
 | `model_a` | ModelConfig or string | No | Model A config or dataset column name |
 | `model_b` | ModelConfig or string | No | Model B config or dataset column name |
+| `disable_position_bias_correction` | boolean | No | Defaults to `false`. When `false`, the judge runs twice per sample (A then B, then B then A) and the verdicts are reconciled to cancel position bias; disagreements become "Tie". Set to `true` to run only the original-order pass, halving judge cost and latency at the cost of position-bias correction. |
+
+When both `model_a` and `model_b` are model configuration objects (not pre-generated column references), Together runs their inference in parallel, reducing total wall-clock time.
 
 ## Judge Model Configuration
 
@@ -79,6 +82,9 @@ Authentication: `Authorization: Bearer $TOGETHER_API_KEY`
 | `model` | string | Yes | Model name, endpoint ID, or external shortcut |
 | `model_source` | string | Yes | `serverless`, `dedicated`, or `external` |
 | `system_template` | string | Yes | Jinja2 system prompt for the judge |
+| `max_tokens` | integer | No | Max tokens for the judge. Defaults to 32768. Increase for reasoning judges (e.g., Gemini or o-series) that consume output budget for chain-of-thought. |
+| `temperature` | float | No | Sampling temperature for the judge. Defaults to 0.05. |
+| `num_workers` | integer | No | Concurrent workers for judge inference. Defaults: `serverless` → 25, `dedicated` → 5 (minimum), `external` → 2 for first-party APIs (OpenAI, Anthropic, Google) or 20 for proxy/aggregator endpoints (e.g. OpenRouter). Override to tune throughput. |
 | `external_api_token` | string | No | API key for external providers |
 | `external_base_url` | string | No | Custom OpenAI-compatible base URL |
 
@@ -92,6 +98,7 @@ Authentication: `Authorization: Bearer $TOGETHER_API_KEY`
 | `input_template` | string | Yes | Jinja2 input template (e.g., `{{prompt}}`) |
 | `max_tokens` | integer | Yes | Maximum generation tokens |
 | `temperature` | float | Yes | Generation temperature (0 to 2) |
+| `num_workers` | integer | No | Concurrent workers for target inference. Defaults: `serverless` → 25, `dedicated` → 5 (minimum), `external` → 2 for first-party APIs or 20 for proxy endpoints. Override to tune throughput. |
 | `external_api_token` | string | No | API key for external providers |
 | `external_base_url` | string | No | Custom OpenAI-compatible base URL |
 
@@ -725,6 +732,7 @@ together evals create [OPTIONS]
 | `--model-a-source [serverless\|dedicated\|external]` | Compare: source of model A |
 | `--model-b TEXT` | Compare: model B name |
 | `--model-b-source [serverless\|dedicated\|external]` | Compare: source of model B |
+| `--disable-position-bias-correction` | Compare: skip the flipped-order judge pass and run only a single judge pass (original order). Halves judge cost and latency at the expense of position-bias correction. Default: off (two-pass mode). |
 
 ### List
 

--- a/skills/together-evaluations/scripts/run_evaluation.py
+++ b/skills/together-evaluations/scripts/run_evaluation.py
@@ -320,14 +320,19 @@ def run_compare(args: argparse.Namespace, dataset: list[dict[str, Any]]) -> None
             external_base_url=args.model_b_external_base_url,
         )
 
+    parameters: dict[str, Any] = {
+        "input_data_file_path": file_id,
+        "judge": build_judge_config(args, DEFAULT_COMPARE_TEMPLATE),
+        "model_a": model_a,
+        "model_b": model_b,
+    }
+    if args.disable_position_bias_correction:
+        parameters["disable_position_bias_correction"] = True
+        print("Position-bias correction disabled — running a single judge pass")
+
     evaluation = client.evals.create(
         type="compare",
-        parameters={
-            "input_data_file_path": file_id,
-            "judge": build_judge_config(args, DEFAULT_COMPARE_TEMPLATE),
-            "model_a": model_a,
-            "model_b": model_b,
-        },
+        parameters=parameters,
     )
     print(f"Created evaluation: {evaluation.workflow_id}")
 
@@ -409,6 +414,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model-b-external-api-token", help="API key for external model B")
     parser.add_argument("--model-b-external-base-url", help="Custom OpenAI-compatible base URL for model B")
     parser.add_argument(
+        "--disable-position-bias-correction",
+        action="store_true",
+        help=(
+            "Compare only: skip the flipped-order judge pass and run a single pass. "
+            "Halves judge cost and latency at the expense of position-bias correction."
+        ),
+    )
+    parser.add_argument(
         "--poll-interval",
         type=int,
         default=5,
@@ -424,6 +437,8 @@ def parse_args() -> argparse.Namespace:
         parser.error("--model-a-column and --model-b-column must be provided together")
     if args.type != "compare" and (args.model_a_column or args.model_b_column):
         parser.error("--model-a-column and --model-b-column only apply to --type compare")
+    if args.type != "compare" and args.disable_position_bias_correction:
+        parser.error("--disable-position-bias-correction only applies to --type compare")
     return args
 
 

--- a/skills/together-evaluations/scripts/run_evaluation.ts
+++ b/skills/together-evaluations/scripts/run_evaluation.ts
@@ -58,6 +58,7 @@ type ScriptArgs = {
   modelBColumn?: string;
   modelBExternalApiToken?: string;
   modelBExternalBaseUrl?: string;
+  disablePositionBiasCorrection: boolean;
   pollInterval: number;
   downloadResults?: string;
 };
@@ -103,12 +104,21 @@ Flags:
   --model-b-column COLUMN
   --model-b-external-api-token TOKEN
   --model-b-external-base-url URL
+  --disable-position-bias-correction
   --poll-interval SECONDS
   --download-results PATH`);
 }
 
-function parseFlagMap(argv: string[]): Record<string, string> {
+const BOOLEAN_FLAGS = new Set(["disable-position-bias-correction"]);
+
+type ParsedFlags = {
+  values: Record<string, string>;
+  bools: Set<string>;
+};
+
+function parseFlagMap(argv: string[]): ParsedFlags {
   const values: Record<string, string> = {};
+  const bools = new Set<string>();
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -119,15 +129,20 @@ function parseFlagMap(argv: string[]): Record<string, string> {
     if (!arg.startsWith("--")) {
       throw new Error(`Unexpected argument: ${arg}`);
     }
+    const flagName = arg.slice(2);
+    if (BOOLEAN_FLAGS.has(flagName)) {
+      bools.add(flagName);
+      continue;
+    }
     const next = argv[i + 1];
     if (!next || next.startsWith("--")) {
       throw new Error(`Missing value for ${arg}`);
     }
-    values[arg.slice(2)] = next;
+    values[flagName] = next;
     i += 1;
   }
 
-  return values;
+  return { values, bools };
 }
 
 function parseEvalType(value: string | undefined): EvalType {
@@ -158,7 +173,7 @@ function parseNumber(value: string | undefined, fallback: number, flagName: stri
 }
 
 function parseScriptArgs(): ScriptArgs {
-  const flags = parseFlagMap(process.argv.slice(2));
+  const { values: flags, bools } = parseFlagMap(process.argv.slice(2));
   const type = parseEvalType(flags.type);
 
   const args: ScriptArgs = {
@@ -188,6 +203,7 @@ function parseScriptArgs(): ScriptArgs {
     modelBColumn: flags["model-b-column"],
     modelBExternalApiToken: flags["model-b-external-api-token"],
     modelBExternalBaseUrl: flags["model-b-external-base-url"],
+    disablePositionBiasCorrection: bools.has("disable-position-bias-correction"),
     pollInterval: parseNumber(flags["poll-interval"], 5, "--poll-interval"),
     downloadResults: flags["download-results"],
   };
@@ -197,6 +213,9 @@ function parseScriptArgs(): ScriptArgs {
   }
   if (args.type !== "compare" && (args.modelAColumn || args.modelBColumn)) {
     throw new Error("--model-a-column and --model-b-column only apply to --type compare");
+  }
+  if (args.type !== "compare" && args.disablePositionBiasCorrection) {
+    throw new Error("--disable-position-bias-correction only applies to --type compare");
   }
 
   return args;
@@ -484,14 +503,20 @@ async function runCompare(args: ScriptArgs, dataset: DatasetRow[]): Promise<void
     console.log(`Using dataset columns for comparisons: ${modelA} vs ${modelB}`);
   }
 
+  const parameters: Record<string, unknown> = {
+    input_data_file_path: fileId,
+    judge: buildJudgeConfig(args, DEFAULT_COMPARE_TEMPLATE),
+    model_a: modelA,
+    model_b: modelB,
+  };
+  if (args.disablePositionBiasCorrection) {
+    parameters.disable_position_bias_correction = true;
+    console.log("Position-bias correction disabled — running a single judge pass");
+  }
+
   const evaluation = await client.evals.create({
     type: "compare",
-    parameters: {
-      input_data_file_path: fileId,
-      judge: buildJudgeConfig(args, DEFAULT_COMPARE_TEMPLATE),
-      model_a: modelA,
-      model_b: modelB,
-    },
+    parameters: parameters as any,
   });
   console.log(`Created evaluation: ${evaluation.workflow_id}`);
 


### PR DESCRIPTION
Sync `together-evaluations` skill with merged docs PR togethercomputer/mintlify-docs#871 ("[MOSH-2737] docs(eval): add disable_position_bias_correction and parallel inference notes").

### Changed docs files
- `docs/ai-evaluations.mdx`

### Skill changes
- `references/api-reference.md`: add `disable_position_bias_correction` row to Compare Parameters and note parallel inference for compare jobs when both `model_a` and `model_b` are config objects.
- `references/api-reference.md`: add `num_workers` row (plus `max_tokens` / `temperature` for completeness) to Judge and Model Configuration tables with the now-documented defaults (`serverless` → 25, `dedicated` → 5 minimum, `external` → 2 first-party or 20 proxy).
- `references/api-reference.md`: add `--disable-position-bias-correction` row to the CLI compare options table.
- `scripts/run_evaluation.py`: accept `--disable-position-bias-correction` (compare-only) and forward it as `disable_position_bias_correction: true` when set.
- `scripts/run_evaluation.ts`: accept the same flag, including boolean-flag support in the lightweight argv parser.

Generated by the Sync Skills Cursor Automation. Please review before merging.
