### PR TITLE
DX-596-together-audio: sync with mintlify-docs#876

### DIFF
--- a/skills/together-audio/SKILL.md
+++ b/skills/together-audio/SKILL.md
@@ -58,6 +58,7 @@ Use Together AI audio APIs for:
 - REST TTS returns a `BinaryAPIResponse`; call `response.write_to_file(path)` to save it. Do NOT use `stream_to_file` (it does not exist on this object).
 - Streaming TTS (`stream=True`) returns a `Stream` of `AudioSpeechStreamChunk` objects. Iterate chunks, check `chunk.type`, and decode `base64.b64decode(chunk.delta)` for audio data. There is no file-writing helper on the stream object.
 - Use `client.audio.transcriptions.create()` for transcription and `client.audio.translations.create()` for translation.
+- Batch transcription and translation share hard limits: 500 MB direct upload, 1 GB URL-fetch, 4 hours of audio per request. For larger payloads, pass a public HTTPS URL on `file=`; for longer audio, split into ≤ 4 h chunks. See the Limits section of [references/stt-models.md](references/stt-models.md).
 - Realtime APIs require audio-format discipline; confirm PCM expectations before streaming bytes.
 - Diarization and word timestamps change response shape; code for the richer verbose output explicitly.
 

--- a/skills/together-audio/references/stt-models.md
+++ b/skills/together-audio/references/stt-models.md
@@ -3,10 +3,12 @@
 
 - [Model Catalog](#model-catalog)
 - [Supported Input Formats](#supported-input-formats)
+- [Limits](#limits)
 - [Audio Transcriptions](#audio-transcriptions)
 - [Audio Translations](#audio-translations)
 - [Realtime Transcription (WebSocket)](#realtime-transcription)
 - [Response Formats](#response-formats)
+- [Errors and Troubleshooting](#errors-and-troubleshooting)
 - [Common Workflows](#common-workflows)
 - [Async Support](#async-support)
 
@@ -37,6 +39,21 @@ The guide and reference both list:
 - `.m4a` (`audio/mp4`)
 - `.webm` (`audio/webm`)
 - `.flac` (`audio/flac`)
+
+## Limits
+
+Both `/v1/audio/transcriptions` and `/v1/audio/translations` enforce the same caps.
+
+| Limit | Value | Notes |
+|-------|-------|-------|
+| Max file size (direct upload) | 500 MB | Requests above this are rejected at the edge with `HTTP 413 Payload Too Large`. |
+| Max file size (URL fetch) | 1 GB | When you submit an HTTPS URL on the `file` field instead of binary, the server downloads up to 1 GB. Larger downloads fail with `400 file_too_large`. |
+| Max audio duration | 4 hours per request | Longer audio is rejected with `400 audio_too_long`. Split into ≤ 4 h segments and submit separately. |
+
+Tips:
+- For payloads larger than 500 MB, host the file at a public HTTPS URL and pass that URL as the `file` field — the 500 MB edge cap only applies to direct uploads.
+- For audio longer than 4 hours, split into ≤ 4 h chunks before submitting.
+- Real-time/streaming transports are unaffected by these batch upload limits.
 
 ## Audio Transcriptions
 
@@ -189,6 +206,20 @@ Speaker segment example:
   "words": [{"word": "Hello", "start": 6.268, "end": 11.314, "speaker_id": "SPEAKER_01"}]
 }
 ```
+
+## Errors and Troubleshooting
+
+`/v1/audio/transcriptions` and `/v1/audio/translations` share the same code path and return the same error codes.
+
+| Response | Meaning | Recommended action |
+|----------|---------|--------------------|
+| `400 audio_too_long` | Audio duration exceeds the 4 hour cap. | Split the file into ≤ 4 h segments and submit separately. |
+| `400 file_too_large` | A URL-fetched audio download exceeded the 1 GB server-side cap. | Compress the source, or split into smaller files. |
+| `400 unsupported_format` | The audio container or codec could not be decoded. | Re-encode to a supported format. Run `ffprobe` on the file to confirm it is valid audio. |
+| `400 invalid_params` | Request parameters failed validation. | Check the API reference for the endpoint. |
+| `413 Payload Too Large` | A direct upload exceeded the 500 MB edge limit. | Submit the file via an HTTPS URL on the `file` field instead, or split the file. The 413 response is plain HTML, not JSON. |
+| `429` | Rate limit exceeded. | See serverless rate limits. |
+| `500 processing_failed` | Internal decode failure after the file was accepted. | Verify the file is valid audio with `ffprobe`. If it is, contact Together support with the response `id`. |
 
 ## Common Workflows
 


### PR DESCRIPTION
Sync with [togethercomputer/mintlify-docs#876](https://github.com/togethercomputer/mintlify-docs/pull/876) — *MLE-5579: Document audio transcription size + duration limits*.

### Triggering doc changes

- `docs/inference/transcription/overview.mdx` — added a `Limits` table (500 MB direct upload, 1 GB URL fetch, 4 h duration).
- `docs/inference/transcription/features.mdx` — added an `Errors and troubleshooting` section mapping each response code to a recommended action.
- `docs/inference/transcription/translation.mdx` — clarified that `/v1/audio/translations` shares the same limits and error codes.

### Skill changes

- `skills/together-audio/references/stt-models.md` — added a `Limits` section enumerating the 500 MB direct-upload cap, 1 GB URL-fetch cap, and 4 h duration cap.
- `skills/together-audio/references/stt-models.md` — added an `Errors and Troubleshooting` table for `audio_too_long`, `file_too_large`, `unsupported_format`, `invalid_params`, `413`, `429`, and `processing_failed`.
- `skills/together-audio/references/stt-models.md` — updated the `Contents` TOC.
- `skills/together-audio/SKILL.md` — added one bullet under `High-Signal Rules` so agents pick the right transport (URL vs direct upload, chunking) up front and link into the new `Limits` section.

Validated locally with `scripts/quick_validate.py` and `scripts/quality_check.py` — both pass.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.
