### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#888

### DIFF
--- a/skills/together-chat-completions/references/api-parameters.md
+++ b/skills/together-chat-completions/references/api-parameters.md
@@ -268,7 +268,7 @@ for await (const chunk of stream) {
 
 ```python
 stream = client.chat.completions.create(
-    model="moonshotai/Kimi-K2.5",
+    model="moonshotai/Kimi-K2.6",
     messages=[{"role": "user", "content": "Which is bigger, 9.11 or 9.9?"}],
     reasoning={"enabled": True},
     temperature=1.0,
@@ -293,7 +293,7 @@ type ReasoningDelta = ChatCompletionChunk.Choice.Delta & {
 };
 
 const stream = await together.chat.completions.create({
-  model: "moonshotai/Kimi-K2.5",
+  model: "moonshotai/Kimi-K2.6",
   messages: [{ role: "user", content: "Which is bigger, 9.11 or 9.9?" }],
   reasoning: { enabled: true },
   temperature: 1.0,

--- a/skills/together-chat-completions/references/function-calling-patterns.md
+++ b/skills/together-chat-completions/references/function-calling-patterns.md
@@ -705,7 +705,7 @@ const final = await together.chat.completions.create({
 
 ## Supported Models
 
-openai/gpt-oss-120b, openai/gpt-oss-20b, moonshotai/Kimi-K2.6, moonshotai/Kimi-K2.5,
+openai/gpt-oss-120b, openai/gpt-oss-20b, moonshotai/Kimi-K2.6,
 zai-org/GLM-5.1, zai-org/GLM-5, MiniMaxAI/MiniMax-M2.7, Qwen/Qwen3.5-397B-A17B,
 Qwen/Qwen3.5-9B, Qwen/Qwen3.6-Plus, Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8,
 Qwen/Qwen3-235B-A22B-Instruct-2507-tput, deepseek-ai/DeepSeek-V4-Pro,

--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -10,7 +10,7 @@
 | Small & Fast | GPT-OSS 20B | `openai/gpt-oss-20b` | `Qwen/Qwen2.5-7B-Instruct-Turbo`, `google/gemma-3n-E4B-it` |
 | Medium General | GPT-OSS 120B | `openai/gpt-oss-120b` | `zai-org/GLM-5` |
 | Function Calling | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` |
-| Vision | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | `moonshotai/Kimi-K2.5`, `google/gemma-4-31B-it` |
+| Vision | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | `Qwen/Qwen3.5-9B`, `google/gemma-4-31B-it` |
 
 ## Full Chat Model Catalog
 
@@ -23,7 +23,6 @@
 | Qwen | Qwen3-Coder 480B | `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` | 256,000 | FP8 |
 | Qwen | Qwen3 235B Instruct | `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` | 262,144 | FP8 |
 | Moonshot | Kimi K2.6 | `moonshotai/Kimi-K2.6` | 262,144 | FP4 |
-| Moonshot | Kimi K2.5 | `moonshotai/Kimi-K2.5` | 262,144 | FP4 |
 | DeepSeek | DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` | 512,000 | FP4 |
 | OpenAI | GPT-OSS 120B | `openai/gpt-oss-120b` | 128,000 | MXFP4 |
 | OpenAI | GPT-OSS 20B | `openai/gpt-oss-20b` | 128,000 | MXFP4 |
@@ -45,7 +44,6 @@
 | Qwen | Qwen3.5 397B A17B | `Qwen/Qwen3.5-397B-A17B` | 262,144 |
 | Qwen | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | 262,144 |
 | Google | Gemma 4 31B IT | `google/gemma-4-31B-it` | 262,144 |
-| Moonshot | Kimi K2.5 | `moonshotai/Kimi-K2.5` | 262,144 |
 
 ## Moderation Models
 

--- a/skills/together-chat-completions/references/reasoning-models.md
+++ b/skills/together-chat-completions/references/reasoning-models.md
@@ -20,7 +20,6 @@
 | GPT-OSS 120B | `openai/gpt-oss-120b` | Adjustable effort | 128K | No |
 | GPT-OSS 20B | `openai/gpt-oss-20b` | Adjustable effort | 128K | No |
 | Kimi K2.6 | `moonshotai/Kimi-K2.6` | Hybrid (on by default) | 262K | Yes |
-| Kimi K2.5 | `moonshotai/Kimi-K2.5` | Hybrid (on by default) | 262K | Yes |
 | MiniMax M2.7 | `MiniMaxAI/MiniMax-M2.7` | Reasoning only | 202K | Yes |
 | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | Hybrid (on by default) | 262K | Yes |
 | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | Hybrid (on by default) | 262K | Yes |
@@ -107,7 +106,6 @@ Hybrid models support `reasoning={"enabled": True/False}` to toggle reasoning on
 - `Qwen/Qwen3.5-9B` (on by default)
 - `Qwen/Qwen3.6-Plus` (on by default)
 - `moonshotai/Kimi-K2.6` (on by default)
-- `moonshotai/Kimi-K2.5` (on by default)
 - `zai-org/GLM-5.1` (on by default)
 - `zai-org/GLM-5` (on by default)
 
@@ -402,7 +400,7 @@ if (completion?.choices?.[0]?.message?.content) {
 - Strong performance on math, code, and agentic tool use
 - Avoid micromanaging reasoning steps -- let the model determine methodology
 
-### Kimi K2.6 / K2.5
+### Kimi K2.6
 - Temperature 1.0 for thinking mode, 0.6 for instant mode
 - Supports both reasoning and non-reasoning modes
 - Excels at multi-turn tool calling with reasoning interleaved

--- a/skills/together-chat-completions/references/structured-outputs.md
+++ b/skills/together-chat-completions/references/structured-outputs.md
@@ -509,7 +509,6 @@ console.log(`Title: ${result.title}`);
 - `openai/gpt-oss-120b`
 - `openai/gpt-oss-20b`
 - `moonshotai/Kimi-K2.6`
-- `moonshotai/Kimi-K2.5`
 - `zai-org/GLM-5.1`
 - `zai-org/GLM-5`
 - `MiniMaxAI/MiniMax-M2.7`

--- a/skills/together-chat-completions/scripts/reasoning_models.py
+++ b/skills/together-chat-completions/scripts/reasoning_models.py
@@ -21,9 +21,9 @@ client = Together()
 
 def reasoning_field_streaming() -> None:
     """Most reasoning models return a separate `reasoning` field."""
-    print("=== Reasoning Field (Kimi K2.5 streaming) ===")
+    print("=== Reasoning Field (Kimi K2.6 streaming) ===")
     stream = client.chat.completions.create(
-        model="moonshotai/Kimi-K2.5",
+        model="moonshotai/Kimi-K2.6",
         messages=[
             {"role": "user", "content": "Which number is bigger, 9.11 or 9.9?"},
         ],
@@ -49,7 +49,7 @@ def reasoning_field_non_streaming() -> None:
     """Non-streaming access to reasoning field."""
     print("=== Reasoning Field (non-streaming) ===")
     response = client.chat.completions.create(
-        model="moonshotai/Kimi-K2.5",
+        model="moonshotai/Kimi-K2.6",
         messages=[{"role": "user", "content": "What is 15% of 240?"}],
     )
     print(f"Reasoning: {response.choices[0].message.reasoning[:200]}...")
@@ -106,12 +106,12 @@ def reasoning_effort_example() -> None:
 
 def toggle_reasoning() -> None:
     """Enable/disable reasoning on hybrid models."""
-    print("=== Toggle Reasoning (Kimi K2.5) ===")
+    print("=== Toggle Reasoning (Kimi K2.6) ===")
 
     # Reasoning enabled (thinking mode)
     print("  [reasoning=True]")
     stream = client.chat.completions.create(
-        model="moonshotai/Kimi-K2.5",
+        model="moonshotai/Kimi-K2.6",
         messages=[{"role": "user", "content": "What is the capital of France?"}],
         reasoning={"enabled": True},
         temperature=1.0,
@@ -134,7 +134,7 @@ def toggle_reasoning() -> None:
     # Reasoning disabled (instant mode)
     print("  [reasoning=False]")
     response = client.chat.completions.create(
-        model="moonshotai/Kimi-K2.5",
+        model="moonshotai/Kimi-K2.6",
         messages=[{"role": "user", "content": "What is the capital of France?"}],
         reasoning={"enabled": False},
         temperature=0.6,

--- a/skills/together-chat-completions/scripts/reasoning_models.ts
+++ b/skills/together-chat-completions/scripts/reasoning_models.ts
@@ -34,10 +34,10 @@ type ReasoningParams = CompletionCreateParamsStreaming & {
 
 // --- 1. Reasoning field (streaming) ---
 async function reasoningFieldStreaming(): Promise<void> {
-  console.log("=== Reasoning Field (Kimi K2.5 streaming) ===");
+  console.log("=== Reasoning Field (Kimi K2.6 streaming) ===");
 
   const stream = await client.chat.completions.stream({
-    model: "moonshotai/Kimi-K2.5",
+    model: "moonshotai/Kimi-K2.6",
     messages: [
       { role: "user", content: "Which number is bigger, 9.11 or 9.9?" },
     ],
@@ -110,12 +110,12 @@ async function reasoningEffortExample(): Promise<void> {
 
 // --- 4. Toggle reasoning on hybrid models ---
 async function toggleReasoning(): Promise<void> {
-  console.log("=== Toggle Reasoning (Kimi K2.5) ===");
+  console.log("=== Toggle Reasoning (Kimi K2.6) ===");
 
   // Reasoning enabled (thinking mode)
   console.log("  [reasoning=true]");
   const enabledParams: ReasoningParams = {
-    model: "moonshotai/Kimi-K2.5",
+    model: "moonshotai/Kimi-K2.6",
     messages: [
       { role: "user", content: "What is the capital of France?" },
     ],
@@ -140,7 +140,7 @@ async function toggleReasoning(): Promise<void> {
   // Reasoning disabled (instant mode)
   console.log("  [reasoning=false]");
   const disabledParams = {
-    model: "moonshotai/Kimi-K2.5",
+    model: "moonshotai/Kimi-K2.6",
     messages: [
       { role: "user", content: "What is the capital of France?" },
     ] as ChatCompletionMessageParam[],


### PR DESCRIPTION
Syncs `together-chat-completions` with the merged mintlify-docs PR
[togethercomputer/mintlify-docs#888 — MLE-5307: docs: deprecate Kimi-K2.5 from serverless](https://github.com/togethercomputer/mintlify-docs/pull/888),
which removes `moonshotai/Kimi-K2.5` from the serverless catalog (it is also listed as not
available on on-demand dedicated endpoints in the deprecations table).

## Triggering doc changes

- `docs/serverless/models.mdx` — removes the `moonshotai/Kimi-K2.5` row from both the chat and vision serverless model tables.
- `docs/deprecations.mdx` and `docs/changelog.mdx` — record the deprecation (informational only; not mapped to a skill).

## Skill changes

- `references/models.md`: drop `Kimi K2.5` from the chat catalog and vision tables; replace it as a vision alternative in the recommended-by-use-case table.
- `references/reasoning-models.md`: drop the `Kimi K2.5` row from the model table and the bullet from the hybrid-models list; collapse the `Kimi K2.6 / K2.5` best-practices heading to `Kimi K2.6`.
- `references/structured-outputs.md`: drop `moonshotai/Kimi-K2.5` from the supported-models list.
- `references/function-calling-patterns.md`: drop `moonshotai/Kimi-K2.5` from the supported tool-calling models list.
- `references/api-parameters.md`: switch the `reasoning={"enabled": True}` Python/TypeScript examples to `moonshotai/Kimi-K2.6`.
- `scripts/reasoning_models.py` and `scripts/reasoning_models.ts`: switch the hybrid reasoning streaming, non-streaming, and toggle examples from `moonshotai/Kimi-K2.5` to `moonshotai/Kimi-K2.6` (same hybrid-on-by-default behavior).

Generated by the Sync Skills Cursor Automation. Please review before merging.
