### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#889

### DIFF
--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -6,10 +6,10 @@
 |----------|-------|-----------|-------------|
 | Chat (best) | Kimi K2.6 | `moonshotai/Kimi-K2.6` | `MiniMaxAI/MiniMax-M2.7`, `openai/gpt-oss-120b` |
 | Reasoning | DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` | `moonshotai/Kimi-K2.6`, `Qwen/Qwen3.6-Plus` |
-| Coding Agents | Qwen3-Coder 480B | `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` | `moonshotai/Kimi-K2.6`, `deepseek-ai/DeepSeek-V4-Pro` |
+| Coding Agents | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `deepseek-ai/DeepSeek-V4-Pro`, `MiniMaxAI/MiniMax-M2.7` |
 | Small & Fast | GPT-OSS 20B | `openai/gpt-oss-20b` | `Qwen/Qwen2.5-7B-Instruct-Turbo`, `google/gemma-3n-E4B-it` |
 | Medium General | GPT-OSS 120B | `openai/gpt-oss-120b` | `zai-org/GLM-5` |
-| Function Calling | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` |
+| Function Calling | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `deepseek-ai/DeepSeek-V4-Pro` |
 | Vision | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | `moonshotai/Kimi-K2.5`, `google/gemma-4-31B-it` |
 
 ## Full Chat Model Catalog
@@ -20,7 +20,6 @@
 | Qwen | Qwen3.5 397B A17B | `Qwen/Qwen3.5-397B-A17B` | 262,144 | BF16 |
 | Qwen | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | 1,000,000 | - |
 | Qwen | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | 262,144 | FP8 |
-| Qwen | Qwen3-Coder 480B | `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` | 256,000 | FP8 |
 | Qwen | Qwen3 235B Instruct | `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` | 262,144 | FP8 |
 | Moonshot | Kimi K2.6 | `moonshotai/Kimi-K2.6` | 262,144 | FP4 |
 | Moonshot | Kimi K2.5 | `moonshotai/Kimi-K2.5` | 262,144 | FP4 |


### PR DESCRIPTION
Sync skill with merged mintlify-docs PR: [#889 — MLE-5617: docs: deprecate Qwen3-Coder-480B-A35B-Instruct-FP8 from serverless](https://github.com/togethercomputer/mintlify-docs/pull/889).

### Triggering doc changes

- `docs/serverless/models.mdx` — removed `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` from the serverless models table.
- `docs/deprecations.mdx` — added `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` to the deprecation table (removal date 2026-06-04, supported on dedicated endpoints).
- `docs/changelog.mdx` — added a deprecation announcement recommending `MiniMaxAI/MiniMax-M2.7` as the replacement.

### Skill changes

- `references/models.md` — switched the **Coding Agents** primary recommendation from `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` to `zai-org/GLM-5.1`, matching the upstream `docs/inference/recommended-models.mdx`.
- `references/models.md` — broadened the Coding Agents alternatives to include `MiniMaxAI/MiniMax-M2.7` (the deprecation's recommended replacement).
- `references/models.md` — replaced `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` with `deepseek-ai/DeepSeek-V4-Pro` in the **Function Calling** alternatives list.
- `references/models.md` — removed the `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` row from the full chat model catalog, since it is no longer listed in the serverless models table.

Generated by the Sync Skills Cursor Automation. Please review before merging.