### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#890

### DIFF
--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -17,6 +17,7 @@
 | Organization | Model | API String | Context | Quant |
 |-------------|-------|-----------|---------|-------|
 | MiniMax | MiniMax M2.7 | `MiniMaxAI/MiniMax-M2.7` | 202,752 | FP4 |
+| Qwen | Qwen3.7 Max | `Qwen/Qwen3.7-Max` | - | - |
 | Qwen | Qwen3.5 397B A17B | `Qwen/Qwen3.5-397B-A17B` | 262,144 | BF16 |
 | Qwen | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | 1,000,000 | - |
 | Qwen | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | 262,144 | FP8 |


### PR DESCRIPTION
Syncs the `together-chat-completions` skill with merged [togethercomputer/mintlify-docs#890](https://github.com/togethercomputer/mintlify-docs/pull/890) ("ENG-88159: Add Qwen3.7-Max serverless model").

## Triggering doc changes

- `docs/serverless/models.mdx`: added `Qwen/Qwen3.7-Max` to the serverless catalog (input \$2.50 / output \$7.50 per 1M tokens; context length and quantization not listed)
- `docs/changelog.mdx`: corresponding changelog entry

## Skill changes

- `skills/together-chat-completions/references/models.md`: add a row for `Qwen/Qwen3.7-Max` to the "Full Chat Model Catalog" table (Qwen section, with context and quant marked `-` to mirror upstream)

No other reference files, scripts, or `SKILL.md` content were touched — Qwen3.7-Max is not yet a recommended model for any use case, has no documented function-calling / structured-output / vision / reasoning support, and pricing is not tracked in this skill's catalog.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.
