### PR TITLE
DX-596-together-dedicated-containers: sync with mintlify-docs#893

### DIFF
--- a/skills/together-dedicated-containers/references/sprocket-sdk.md
+++ b/skills/together-dedicated-containers/references/sprocket-sdk.md
@@ -5,7 +5,7 @@
 - [Installation](#installation)
 - [Core Pattern](#core-pattern)
 - [`sprocket.Sprocket` Base Class](#sprocketsprocket-base-class)
-- [`sprocket.run(sprocket, name, use_torchrun=False)`](#sprocketrun)
+- [`sprocket.run(sprocket, name=None, use_torchrun=False)`](#sprocketrun)
 - [`sprocket.FileOutput`](#sprocketfileoutput)
 - [`sprocket.emit_info(info: dict)`](#sprocketemitinfo)
 - [`sprocket.InputOutputProcessor`](#sprocketinputoutputprocessor)
@@ -49,7 +49,7 @@ class MyModel(sprocket.Sprocket):
         pass
 
 if __name__ == "__main__":
-    sprocket.run(MyModel(), "my-deployment")
+    sprocket.run(MyModel())
 ```
 
 ## `sprocket.Sprocket` Base Class
@@ -69,12 +69,12 @@ if __name__ == "__main__":
 | `processor` | `Type[InputOutputProcessor]` | `InputOutputProcessor` | Custom I/O processor |
 | `warmup_inputs` | `list[dict]` | `[]` | Inputs for cache warmup |
 
-## `sprocket.run(sprocket, name, use_torchrun=False)`
+## `sprocket.run(sprocket, name=None, use_torchrun=False)`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `sprocket` | Sprocket | Your Sprocket instance |
-| `name` | str | Deployment name (used for queue routing) |
+| `name` | str \| None | Optional deployment/queue name. If omitted, Sprocket reads it from the `TOGETHER_DEPLOYMENT_NAME` environment variable that the platform injects at runtime. Pass explicitly only when you need to override the platform-provided name. |
 | `use_torchrun` | bool | Enable multi-GPU mode. Default: False |
 
 ## `sprocket.FileOutput`
@@ -87,7 +87,7 @@ def predict(self, args):
     return {"video": sprocket.FileOutput("output.mp4"), "duration": 10.5}
 ```
 
-The file is uploaded after `predict()` returns, and the path is replaced with a public URL in the final result.
+The file is uploaded after `predict()` returns, and the path is replaced with an access URL in the final result. The URL is not publicly readable -- clients must authenticate with their Together API key (e.g. `Authorization: Bearer $TOGETHER_API_KEY`) when fetching it.
 
 ## `sprocket.emit_info(info: dict)`
 
@@ -167,7 +167,7 @@ class MultiGPUModel(sprocket.Sprocket):
             return {"video": sprocket.FileOutput("result.mp4")}
         # Other ranks return None
 
-sprocket.run(MultiGPUModel(), "my-model", use_torchrun=True)
+sprocket.run(MultiGPUModel(), use_torchrun=True)
 ```
 
 Config for multi-GPU:

--- a/skills/together-dedicated-containers/scripts/sprocket_hello_world.py
+++ b/skills/together-dedicated-containers/scripts/sprocket_hello_world.py
@@ -82,4 +82,4 @@ class HelloModel(sprocket.Sprocket):
 
 
 if __name__ == "__main__":
-    sprocket.run(HelloModel(), "my-org/hello-model")
+    sprocket.run(HelloModel())


### PR DESCRIPTION
Sync of [togethercomputer/mintlify-docs#893](https://github.com/togethercomputer/mintlify-docs/pull/893) ("Eng 88258 fix dci examples in docs", merged commit `33f7253`) into the `together-dedicated-containers` skill.

## Triggering docs changes

- `docs/dedicated_containers_image.mdx`
- `docs/dedicated_containers_video.mdx`

## Skill changes

- `references/sprocket-sdk.md`: mark the `name` argument of `sprocket.run()` as optional in the section header, TOC entry, and parameter table; note it now defaults to the `TOGETHER_DEPLOYMENT_NAME` env var injected by the platform.
- `references/sprocket-sdk.md`: update the Core Pattern and Multi-GPU examples to call `sprocket.run(MyModel())` / `sprocket.run(MultiGPUModel(), use_torchrun=True)` without a hardcoded queue name.
- `references/sprocket-sdk.md`: clarify that `sprocket.FileOutput` upload URLs are not publicly readable -- clients must authenticate with their Together API key when fetching them (the docs example dropped the "public URL" wording for this reason).
- `scripts/sprocket_hello_world.py`: drop the now-unnecessary `"my-org/hello-model"` positional argument from `sprocket.run()`.

Other PR changes (pinned dependency versions in the Flux2/Wan example `pyproject.toml`s, `system_packages = ["gcc", "g++"]` for triton/bitsandbytes, `termination_grace_period_seconds = 600` for the Wan example, switching the Flux2 example to queue mode via `cmd = "python3 run.py --queue"`, and renaming the Wan project to `sprocket-wan`) are example-specific and not generalized into the skill.

Validated locally with `python3 scripts/quick_validate.py skills/together-dedicated-containers` and `python3 scripts/quality_check.py`.

---
Generated by the Sync Skills Cursor Automation. Please review before merging.
