### PR TITLE
DX-596-together-images: sync with mintlify-docs#904

### DIFF
--- a/skills/together-images/references/models.md
+++ b/skills/together-images/references/models.md
@@ -25,7 +25,6 @@
 | Black Forest Labs | FLUX.1.1 [pro] | `black-forest-labs/FLUX.1.1-pro` | - |
 | Black Forest Labs | FLUX.1 Kontext [pro] | `black-forest-labs/FLUX.1-kontext-pro` | 28 |
 | Black Forest Labs | FLUX.1 Kontext [max] | `black-forest-labs/FLUX.1-kontext-max` | 28 |
-| Black Forest Labs | FLUX.1 Krea [dev] | `black-forest-labs/FLUX.1-krea-dev` | 28 |
 | ByteDance | Seedream 4.0 | `ByteDance-Seed/Seedream-4.0` | - |
 | ByteDance | Seedream 3.0 | `ByteDance-Seed/Seedream-3.0` | - |
 | Qwen | Qwen Image | `Qwen/Qwen-Image` | - |


### PR DESCRIPTION
Syncs the `together-images` skill with [togethercomputer/mintlify-docs#904](https://github.com/togethercomputer/mintlify-docs/pull/904) (MLE-5383: Deprecate FLUX.1 Krea [dev] from serverless), merged at sha `0c91cca`.

## Changed docs files that triggered this sync

- `docs/serverless/models.mdx` — removed the `black-forest-labs/FLUX.1-krea-dev` row from the serverless image-model catalog (mapped to `together-images` via `docs/serverless/models.mdx` in `.skills/sync-map.yaml`)
- `docs/deprecations.mdx` — added `2026-05-27` removal row for `black-forest-labs/FLUX.1-krea-dev` (no on-demand dedicated endpoints) — not glob-mapped, used as context
- `docs/changelog.mdx` — added May 27, 2026 deprecation entry — not glob-mapped, used as context

## Skill changes

- Removed the `| Black Forest Labs | FLUX.1 Krea [dev] | \`black-forest-labs/FLUX.1-krea-dev\` | 28 |` row from `skills/together-images/references/models.md` so the catalog matches the now-current serverless table.

No other file in the skill references `FLUX.1-krea-dev` or `Krea`, so no further edits are needed (other FLUX/Kontext references and pricing/feature tables are untouched).

---

Generated by the Sync Skills Cursor Automation. Please review before merging.