### PR TITLE
DX-596-together-gpu-clusters: sync with mintlify-docs#887

### DIFF
--- a/skills/together-gpu-clusters/SKILL.md
+++ b/skills/together-gpu-clusters/SKILL.md
@@ -67,6 +67,7 @@ Typical fits:
 - Credentials retrieval is part of provisioning. Do not stop at cluster creation if the user needs to run workloads immediately.
 - Slurm and Kubernetes operational patterns differ materially; read the cluster-management reference before improvising.
 - For repeated cluster operations, start from the scripts instead of rebuilding request shapes.
+- Slurm startup scripts (worker/login init, worker/controller prolog and epilog, extra `slurm.conf`) are **Slinky v1.0 only**. A non-zero exit from a worker prolog or epilog drains the node, and calling Slurm commands (`squeue`, `scontrol`, `sacctmgr`) inside any prolog/epilog can deadlock the scheduler.
 
 ## Resource Map
 
@@ -83,4 +84,5 @@ Typical fits:
 - [GPU Clusters Overview](https://docs.together.ai/docs/gpu-clusters-overview)
 - [GPU Clusters Quickstart](https://docs.together.ai/docs/gpu-clusters-quickstart)
 - [Clusters API](https://docs.together.ai/reference/clusters-create)
+- [Slurm Startup Scripts](https://docs.together.ai/docs/slurm-startup-scripts)
 - [Instant GPU Clusters](https://www.together.ai/instant-gpu-clusters)

--- a/skills/together-gpu-clusters/references/cluster-management.md
+++ b/skills/together-gpu-clusters/references/cluster-management.md
@@ -4,6 +4,7 @@
 - [Cluster Architecture](#cluster-architecture)
 - [Access Methods](#access-methods)
 - [Slurm Configuration](#slurm-configuration)
+  - [Startup Scripts (Slinky v1.0 only)](#startup-scripts-slinky-v10-only)
 - [GPU Access in Containers](#gpu-access-in-containers)
 - [Scaling](#scaling)
 - [Storage](#storage)
@@ -114,6 +115,42 @@ ConstrainRAMSpace=yes
 
 Changes require restarting the Slurm controller via `kubectl rollout restart` and verifying
 with `scontrol` and `sinfo`.
+
+### Startup Scripts (Slinky v1.0 only)
+
+Lifecycle scripts that run automatically at node startup, job start, and job completion.
+Configure under cluster **Specs and configuration -> Slurm configuration -> Edit**. Every
+script must start with a shebang (`#!/bin/bash`); saving triggers a live Slurm reconfigure,
+so test on a non-critical cluster first.
+
+| Script | Runs on | When |
+|--------|---------|------|
+| Worker init | Each worker | Node boot, before jobs |
+| Login init | Login node | Login-node startup |
+| Worker prolog | Each worker | Before job (first job step by default; see `PrologFlags=Alloc`) |
+| Worker epilog | Each worker | After job ends |
+| Controller prolog | `slurmctld` | At job allocation |
+| Controller epilog | `slurmctld` | At job completion |
+| Extra slurm.conf | All nodes | Appended verbatim to `slurm.conf` |
+
+**Failure modes:**
+
+- Worker prolog or epilog non-zero exit -> node set to `DRAIN`. A worker prolog failure additionally requeues batch jobs and cancels interactive jobs (`salloc`, `srun`).
+- Controller prolog non-zero exit -> batch job requeued, interactive job cancelled; node not affected.
+- Controller epilog non-zero exit -> logged, no other effect.
+
+Resume a drained node:
+
+```shell
+sudo scontrol update NodeName=<node_name> State=resume Reason="script fixed"
+```
+
+**Rules:**
+
+- Do not call Slurm commands (`squeue`, `scontrol`, `sacctmgr`) inside a prolog or epilog; this can deadlock the scheduler.
+- By default the worker prolog runs at first job step, not at allocation. Add `PrologFlags=Alloc` to **Extra slurm.conf** to run at allocation.
+- After edits, existing workers may keep cached scripts via Slurm's configless mechanism. New jobs on those workers continue using the old scripts until the worker restarts.
+- Use `set -e` in init scripts so failures surface immediately; use `SLURM_JOB_ID` and `SLURM_JOB_USER` in prolog/epilog to scope cleanup to the running job.
 
 ## GPU Access in Containers
 


### PR DESCRIPTION
Syncs the `together-gpu-clusters` skill with the new [Slurm startup scripts page](https://docs.together.ai/docs/slurm-startup-scripts) merged in [togethercomputer/mintlify-docs#887](https://github.com/togethercomputer/mintlify-docs/pull/887) (\"[TCl-5106]docs: add Slurm startup scripts page\", merge sha `2c0ecf2`).

### Changed docs files that triggered this sync

- `docs/slurm-startup-scripts.mdx` (new) — matched via `together-gpu-clusters` glob `docs/slurm*.mdx`

### Skill changes

- `references/cluster-management.md`: added a new **Startup Scripts (Slinky v1.0 only)** subsection under *Slurm Configuration*, with a script-type table (worker init, login init, worker prolog, worker epilog, controller prolog, controller epilog, Extra slurm.conf), failure-mode bullets, the drained-node resume command, and operational rules.
- `references/cluster-management.md`: added a TOC entry for the new subsection.
- `SKILL.md`: added one High-Signal Rule covering Slinky-v1.0 scope, the DRAIN failure mode on worker prolog/epilog non-zero exit, and the prolog/epilog -> Slurm-command deadlock risk.
- `SKILL.md`: added the new Slurm Startup Scripts page to Official Docs.

Validated locally with `scripts/quick_validate.py` and `scripts/quality_check.py` — both pass.

Generated by the Sync Skills Cursor Automation. Please review before merging.