### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#910

### DIFF
--- a/skills/together-chat-completions/SKILL.md
+++ b/skills/together-chat-completions/SKILL.md
@@ -49,6 +49,8 @@ clearly offline batch processing, vector retrieval, model training, or infrastru
 - **Tool calling or function calling**
   - Read [references/function-calling-patterns.md](references/function-calling-patterns.md)
   - Start from [scripts/tool_call_loop.py](scripts/tool_call_loop.py) or [scripts/tool_call_loop.ts](scripts/tool_call_loop.ts)
+- **Designing tools, schemas, or tool_choice for reliability**
+  - Read the "Best Practices" section in [references/function-calling-patterns.md](references/function-calling-patterns.md)
 - **Structured outputs**
   - Read [references/structured-outputs.md](references/structured-outputs.md)
   - Start from [scripts/structured_outputs.py](scripts/structured_outputs.py) or [scripts/structured_outputs.ts](scripts/structured_outputs.ts)
@@ -77,6 +79,8 @@ clearly offline batch processing, vector retrieval, model training, or infrastru
 - Use `client.chat.completions.create()` for Python and `client.chat.completions.create()` for TypeScript.
 - Preserve full `messages` history for multi-turn conversations; do not rebuild context from final text only.
 - For tools, implement the full loop: model tool call -> execute tool -> append tool result -> second model call.
+- For tool definitions, prefer `enum` over free-form strings, set `"additionalProperties": false`, and add `"strict": true` on the function definition when you need argument generation to conform to the schema.
+- Tool names must not contain spaces, periods, or dashes. Branch on `finish_reason` (`"tool_calls"` vs `"stop"`) instead of assuming a tool was called, and parse `function.arguments` as JSON inside a try/except.
 - Prefer `json_schema` over looser JSON modes when the user needs stable machine-readable output.
 - Use reasoning models only when the task benefits from deeper deliberation; otherwise prefer cheaper standard models.
 - To combine tool calling with structured output, use a two-phase approach: Phase 1 sends `tools` (no `response_format`), Phase 2 sends `response_format` (no `tools`) after tool results are appended.

--- a/skills/together-chat-completions/references/function-calling-patterns.md
+++ b/skills/together-chat-completions/references/function-calling-patterns.md
@@ -5,6 +5,7 @@
 - [Combining Tool Calls with Structured Output](#combining-tool-calls-with-structured-output)
 - [Processing Tool Calls](#processing-tool-calls)
 - [tool_choice Parameter](#toolchoice-parameter)
+- [Best Practices](#best-practices)
 - [Supported Models](#supported-models)
 
 
@@ -702,6 +703,119 @@ const final = await together.chat.completions.create({
 | `"required"` | Model must call at least one function |
 | `"none"` | Never call functions |
 | `{"type": "function", "function": {"name": "fn"}}` | Force specific function |
+
+## Best Practices
+
+The quality of tool definitions, system prompt, and selection controls determines how reliably the
+model calls functions. Apply these rules when building or debugging a tool-calling app.
+
+### Write tight function descriptions
+
+The description is the only context the model has for deciding when to call a tool and how to fill
+its arguments. Treat it as a short spec:
+
+- State what the tool does and when to use it (and when not to).
+- Describe each parameter's meaning, expected format, and effect on the result.
+- Note caveats: what the tool does not return, edge cases.
+- Describe what the output represents.
+
+Aim for three to four sentences per tool. If a new engineer could correctly call the function from
+the schema alone, the model can too. Fold concrete examples into the description prose or the
+system prompt — the OpenAI-compatible tool schema (`type`, `function.name`,
+`function.description`, `function.parameters`) has no separate examples field.
+
+### Make invalid states unrepresentable
+
+Constrain what the model can produce via JSON Schema rather than validating after the fact:
+
+- Give every parameter a type. Use `enum` whenever the valid values are a fixed set.
+- List the parameters the model must supply in `required`. Leave optional ones out.
+- Replace contradictory flag pairs (e.g. `on: bool, off: bool`) with a single `enum` field
+  (`state: ["on", "off"]`).
+- Set `"additionalProperties": false` on the parameters object so the model cannot add unknown
+  fields.
+- For stricter conformance, add `"strict": true` to the function definition. Together's API accepts
+  it and constrains generated arguments to match your schema:
+
+```python
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current temperature for a location.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City and state, e.g. San Francisco, CA"},
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+                "additionalProperties": False,
+            },
+            "strict": True,
+        },
+    }
+]
+```
+
+### Keep the active tool set small
+
+More tools means more chances to pick the wrong one. Aim for fewer than 20 active tools in `tools`
+per request, and evaluate as the set grows.
+
+- Consolidate related operations: prefer one `manage_ticket` with an `action` enum over separate
+  `create_ticket` / `update_ticket` / `close_ticket` tools.
+- Namespace tool names across services: `github_list_prs`, `slack_send_message`.
+- Scope tools per turn: pass only the subset relevant to the current conversation, not the whole
+  catalog.
+- Tool names must not contain spaces, periods, or dashes (e.g. `get_current_weather`, not
+  `get current weather` or `get-current-weather`).
+
+### Offload work from the model to your code
+
+Don't ask the model to produce information the application already has:
+
+- Drop arguments you already know. If `order_id` is held in app state, expose `submit_refund()`
+  with no arguments and inject the id in your code when executing the call.
+- Combine always-sequential calls into one tool. One round trip is more reliable than two.
+
+### Guide the model with the system prompt
+
+- Give the model a role: `You are a travel planning assistant with access to weather and
+  restaurant tools.`
+- State when to use each tool, and when not to.
+- Forbid guessing: `Do not guess values. If a required detail is missing, ask the user for it
+  before calling a tool.`
+- Encourage clarification when the request is ambiguous.
+
+### Handle responses and errors robustly
+
+Tool calls come back in `message.tool_calls`, not `message.content` (which is often `null` on a
+tool-calling turn). Build the loop defensively:
+
+- Check `finish_reason`: `"tool_calls"` means run a tool; `"stop"` means a normal text reply.
+  Branch on it instead of assuming a tool was called.
+- Parse `function.arguments` as JSON inside a try/except — handle malformed or incomplete JSON.
+- On tool failure, return a clear error payload in the `tool` message content (for example
+  `{"error": "No stock found for symbol XYZ"}`) so the model can recover, rather than throwing.
+- Validate high-consequence calls (orders, refunds, deletes) with the user before executing.
+- Validate and sanitize arguments before acting on them; keep secrets out of tool arguments.
+
+### Tune for reliable calls
+
+- Lower the temperature (e.g. `0`) to make tool selection and argument generation more
+  deterministic. Raise it only when more varied behavior is needed.
+- Stream when latency matters: tool calls stream incrementally through `delta.tool_calls`.
+- Watch the token budget: tool descriptions and schemas count toward input tokens. Tighten or
+  split the tool set if you approach the limit.
+
+### When to fine-tune
+
+Strong descriptions and a focused tool set cover most cases. For higher accuracy across a large
+tool catalog or a difficult domain-specific task, fine-tune a model on your own tool-calling data.
+See the `together-fine-tuning` skill for the function-calling dataset format and training
+workflow.
 
 ## Supported Models
 


### PR DESCRIPTION
Syncs the [function-calling best practices guide](https://github.com/togethercomputer/mintlify-docs/pull/910) merged into mintlify-docs into the `together-chat-completions` skill.

**Source PR:** togethercomputer/mintlify-docs#910 ("DX-633 Add function calling best practices guide")

**Mintlify-docs files that triggered this sync:**
- `docs/inference/function-calling/best-practices.mdx` (new)
- `docs/inference/function-calling/overview.mdx` (added link to best-practices guide)

**Skill changes:**
- Added a new **Best Practices** section to `references/function-calling-patterns.md` covering description writing, schema constraints (`"strict": true`, `additionalProperties: false`, enums, required fields), keeping the active tool set small (<20 tools, naming rules — no spaces/periods/dashes), offloading work from the model, system-prompt guidance, robust response/error handling (`finish_reason` branching, JSON-safe argument parsing), tuning (temperature, streaming, token budget), and when to fine-tune.
- Added a Quick Routing entry in `SKILL.md` for designing tools/schemas and `tool_choice` for reliability.
- Added two High-Signal Rules in `SKILL.md` covering strict schemas / `additionalProperties: false` / `"strict": true`, and `finish_reason` branching with safe JSON parsing of `function.arguments`.

Generated by the Sync Skills Cursor Automation. Please review before merging.