### PR TITLE
DX-596-together-dedicated-containers: sync with mintlify-docs#912

### DIFF
--- a/skills/together-dedicated-containers/references/jig-cli.md
+++ b/skills/together-dedicated-containers/references/jig-cli.md
@@ -20,7 +20,7 @@
 ```shell
 uv pip install "together>=2.0.0"
 # or
-uv tool install together
+uv tool install "together[cli]"
 ```
 
 Jig commands are under `together beta jig`.


### PR DESCRIPTION
Syncs the `together-dedicated-containers` skill with [togethercomputer/mintlify-docs#912](https://github.com/togethercomputer/mintlify-docs/pull/912) ("docs: quote together[cli] in install commands").

### Changed docs that triggered this sync
- `docs/containers-quickstart.mdx`
- `docs/dedicated_containers_image.mdx`
- `docs/dedicated_containers_video.mdx`

### Skill changes
- `references/jig-cli.md`: updated the `uv tool install` command to install the `[cli]` extras and added shell-safe quotes (`uv tool install "together[cli]"`), matching the new canonical install pattern in the docs.

---
Generated by the Sync Skills Cursor Automation. Please review before merging.