### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#918

### DIFF
--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -22,6 +22,7 @@
 | Qwen | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | 1,000,000 | - |
 | Qwen | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | 262,144 | FP8 |
 | Qwen | Qwen3 235B Instruct | `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` | 262,144 | FP8 |
+| Qwen | Qwen3 Coder 480B A35B Instruct | `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` | 262,144 | FP8 |
 | Moonshot | Kimi K2.6 | `moonshotai/Kimi-K2.6` | 262,144 | FP4 |
 | DeepSeek | DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` | 512,000 | FP4 |
 | OpenAI | GPT-OSS 120B | `openai/gpt-oss-120b` | 128,000 | MXFP4 |


### PR DESCRIPTION
Sync with [togethercomputer/mintlify-docs#918](https://github.com/togethercomputer/mintlify-docs/pull/918) ("DX-546: Sync serverless + dedicated endpoint models").

### Changed docs files that triggered this PR

- `docs/serverless/models.mdx` — serverless model catalog

### Skill changes

- Added `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` (Qwen3 Coder 480B A35B Instruct) to the Full Chat Model Catalog table in `references/models.md`. Context length 262,144 tokens, FP8 quantization. The model was already referenced in the Function Calling Recommended Models row but was missing from the full catalog.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.