### PR TITLE
DX-596-together-images: sync with mintlify-docs#926

### DIFF
--- a/skills/together-images/references/api-reference.md
+++ b/skills/together-images/references/api-reference.md
@@ -51,10 +51,10 @@ client = Together()
 
 response = client.images.generate(
     prompt="A sunset over mountains",
-    model="black-forest-labs/FLUX.1-schnell",
+    model="black-forest-labs/FLUX.2-dev",
     width=1024,
     height=1024,
-    steps=4,
+    steps=20,
     n=1,
 )
 print(response.data[0].url)
@@ -66,10 +66,10 @@ const together = new Together();
 
 const response = await together.images.generate({
   prompt: "A sunset over mountains",
-  model: "black-forest-labs/FLUX.1-schnell",
+  model: "black-forest-labs/FLUX.2-dev",
   width: 1024,
   height: 1024,
-  steps: 4,
+  steps: 20,
   n: 1,
 });
 console.log(response.data[0].url);
@@ -81,10 +81,10 @@ curl -X POST "https://api.together.xyz/v1/images/generations" \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "A sunset over mountains",
-    "model": "black-forest-labs/FLUX.1-schnell",
+    "model": "black-forest-labs/FLUX.2-dev",
     "width": 1024,
     "height": 1024,
-    "steps": 4,
+    "steps": 20,
     "n": 1
   }'
 ```
@@ -96,10 +96,10 @@ Use `n` to request multiple candidate images from the same prompt in one call:
 ```python
 response = client.images.generate(
     prompt="A cozy reading nook with warm afternoon light",
-    model="black-forest-labs/FLUX.1-schnell",
+    model="black-forest-labs/FLUX.2-dev",
     width=1024,
     height=1024,
-    steps=4,
+    steps=20,
     n=4,
 )
 
@@ -110,10 +110,10 @@ for image in response.data:
 ```typescript
 const response = await together.images.generate({
   prompt: "A cozy reading nook with warm afternoon light",
-  model: "black-forest-labs/FLUX.1-schnell",
+  model: "black-forest-labs/FLUX.2-dev",
   width: 1024,
   height: 1024,
-  steps: 4,
+  steps: 20,
   n: 4,
 });
 
@@ -295,7 +295,7 @@ curl -X POST "https://api.together.xyz/v1/images/generations" \
 ```json
 {
   "id": "img-abc123",
-  "model": "black-forest-labs/FLUX.1-schnell",
+  "model": "black-forest-labs/FLUX.2-dev",
   "object": "list",
   "data": [
     {
@@ -312,7 +312,7 @@ With `response_format="base64"`:
 ```json
 {
   "id": "img-abc123",
-  "model": "black-forest-labs/FLUX.1-schnell",
+  "model": "black-forest-labs/FLUX.2-dev",
   "object": "list",
   "data": [
     {

--- a/skills/together-images/scripts/generate_image.py
+++ b/skills/together-images/scripts/generate_image.py
@@ -21,10 +21,10 @@ client = Together()
 
 def generate_image_url(
     prompt: str,
-    model: str = "black-forest-labs/FLUX.1-schnell",
+    model: str = "black-forest-labs/FLUX.2-dev",
     width: int = 1024,
     height: int = 1024,
-    steps: int = 4,
+    steps: int = 20,
     n: int = 1,
     seed: int | None = None,
 ) -> list[str]:
@@ -50,10 +50,10 @@ def generate_image_url(
 def generate_and_save(
     prompt: str,
     output_path: str = "output.png",
-    model: str = "black-forest-labs/FLUX.1-schnell",
+    model: str = "black-forest-labs/FLUX.2-dev",
     width: int = 1024,
     height: int = 1024,
-    steps: int = 4,
+    steps: int = 20,
 ) -> str:
     """Generate an image and save it locally via base64."""
     response = client.images.generate(
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     print("=== Basic Generation ===")
     generate_image_url(
         prompt="A serene mountain landscape at sunset, digital art",
-        steps=4,
+        steps=20,
     )
 
     # --- Example 2: Save locally ---
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     generate_and_save(
         prompt="A futuristic city skyline with flying cars",
         output_path="city.png",
-        steps=4,
+        steps=20,
     )
 
     # --- Example 3: Multiple variations ---
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     generate_image_url(
         prompt="A cute robot reading a book",
         n=3,
-        steps=4,
+        steps=20,
     )
 
     # --- Example 4: Reproducible with seed ---
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     generate_image_url(
         prompt="Abstract geometric pattern in blue and gold",
         seed=42,
-        steps=4,
+        steps=20,
     )
 
     # --- Example 5: FLUX.2 with prompt upsampling ---

--- a/skills/together-images/scripts/generate_image.ts
+++ b/skills/together-images/scripts/generate_image.ts
@@ -19,11 +19,11 @@ const client = new Together({
 });
 
 async function basicGeneration(): Promise<void> {
-  console.log("=== Basic Generation (FLUX.1 Schnell) ===");
+  console.log("=== Basic Generation (FLUX.2 Dev) ===");
   const response = await client.images.generate({
-    model: "black-forest-labs/FLUX.1-schnell",
+    model: "black-forest-labs/FLUX.2-dev",
     prompt: "A serene mountain landscape at sunset with a lake reflection",
-    steps: 4,
+    steps: 20,
   });
   console.log(`  Image URL: ${response.data[0].url}`);
 }
@@ -57,10 +57,10 @@ async function kontextEditing(): Promise<void> {
 async function multipleVariations(): Promise<void> {
   console.log("\n=== Multiple Variations ===");
   const response = await client.images.generate({
-    model: "black-forest-labs/FLUX.1-schnell",
+    model: "black-forest-labs/FLUX.2-dev",
     prompt: "A cute robot assistant helping in a modern office",
     n: 4,
-    steps: 4,
+    steps: 20,
   });
   for (let i = 0; i < response.data.length; i++) {
     console.log(`  Variation ${i + 1}: ${response.data[i].url}`);
@@ -70,8 +70,9 @@ async function multipleVariations(): Promise<void> {
 async function base64Response(): Promise<void> {
   console.log("\n=== Base64 Response ===");
   const response = await client.images.generate({
-    model: "black-forest-labs/FLUX.1-schnell",
+    model: "black-forest-labs/FLUX.2-dev",
     prompt: "A cat in outer space",
+    steps: 20,
     response_format: "base64",
   });
   const data = response.data[0].b64_json ?? "";


### PR DESCRIPTION
Sync with [togethercomputer/mintlify-docs#926](https://github.com/togethercomputer/mintlify-docs/pull/926) — "Update image model references in docs" (merged commit `f6a5bee`).

## Changed docs files that triggered this sync

- `docs/inference/images/overview.mdx`

## Skill changes

- Update basic text-to-image example in `references/api-reference.md` (Text-to-Image and Multiple Variations sections) from `black-forest-labs/FLUX.1-schnell` / `steps=4` to `black-forest-labs/FLUX.2-dev` / `steps=20` to match the new docs default.
- Update the model id in the response JSON examples in `references/api-reference.md` to `black-forest-labs/FLUX.2-dev`.
- Update `scripts/generate_image.py`: `generate_image_url` and `generate_and_save` default model to `black-forest-labs/FLUX.2-dev` and default `steps` to 20; align demo calls in `__main__`.
- Update `scripts/generate_image.ts`: `basicGeneration`, `multipleVariations`, and `base64Response` now use `black-forest-labs/FLUX.2-dev` with `steps=20`.
- Kontext editing, LoRA generation, and the model reference catalog were left untouched because the source PR did not change those areas.

Generated by the Sync Skills Cursor Automation. Please review before merging.
