### PR TITLE
DX-596-together-audio: sync with mintlify-docs#931

### DIFF
--- a/skills/together-audio/references/stt-models.md
+++ b/skills/together-audio/references/stt-models.md
@@ -20,7 +20,6 @@ These models are current in the latest speech-to-text guide and are not listed i
 | Model | API String | Access | Capabilities |
 |-------|-----------|--------|--------------|
 | Whisper Large v3 | `openai/whisper-large-v3` | Serverless | Realtime, translation, diarization |
-| Voxtral Mini 3B | `mistralai/Voxtral-Mini-3B-2507` | Serverless | Transcription |
 | Deepgram Flux | `deepgram/deepgram-flux` | Dedicated / Reserved | Realtime |
 | Deepgram Nova 3 | `deepgram/deepgram-nova-3` | Dedicated / Reserved | Transcription |
 | Deepgram Nova 3 Multilingual | `deepgram/deepgram-nova-3-multilingual` | Dedicated / Reserved | Transcription |
@@ -29,7 +28,7 @@ These models are current in the latest speech-to-text guide and are not listed i
 Notes:
 - The `/audio/transcriptions` and `/audio/translations` reference schemas currently enumerate
   `openai/whisper-large-v3` in the request body.
-- The broader guide model catalog also includes Voxtral, Parakeet, and dedicated-endpoint Deepgram models.
+- The broader guide model catalog also includes Parakeet and dedicated-endpoint Deepgram models.
 
 ## Supported Input Formats
 


### PR DESCRIPTION
Syncing skill with togethercomputer/mintlify-docs#931 (merged).

Mintlify-docs PR: https://github.com/togethercomputer/mintlify-docs/pull/931

### Changed docs files that triggered this sync
- `docs/serverless/models.mdx` — removed the `mistralai/Voxtral-Mini-3B-2507` row from the serverless audio (Speech-to-Text) catalog.

### Skill changes
- `skills/together-audio/references/stt-models.md`: drop the `Voxtral Mini 3B` row from the Model Catalog table to match the deprecated/removed serverless listing.
- `skills/together-audio/references/stt-models.md`: update the catalog notes bullet to remove the `Voxtral` mention (now reads "Parakeet, and dedicated-endpoint Deepgram models").

_Generated by the Sync Skills Cursor Automation. Please review before merging._
