### PR TITLE
DX-596-together-fine-tuning: sync with mintlify-docs#932

### DIFF
--- a/skills/together-fine-tuning/references/deployment.md
+++ b/skills/together-fine-tuning/references/deployment.md
@@ -101,7 +101,7 @@ Options:
 | `learning_rate` | float | ~1e-5 | Learning rate |
 | `warmup_ratio` | float | 0 | Warmup step ratio |
 | `lora` | bool | true | Use LoRA method |
-| `lora_r` | int | 64 | LoRA rank |
+| `lora_r` | int | 64 | LoRA rank. Per-model max -- 64 for most models; 16 for Moonshot Kimi-K2 family, Z.ai GLM-5/5.1, and DeepSeek R1/V3 (non-distill) families. See [supported-models.md](supported-models.md). |
 | `lora_alpha` | int | 16 | LoRA scaling factor |
 | `train_on_inputs` | bool/str | "auto" | Train on prompts/user msgs |
 | `n_evals` | int | 0 | Validation evaluations (>0 to use validation set) |

--- a/skills/together-fine-tuning/references/supported-models.md
+++ b/skills/together-fine-tuning/references/supported-models.md
@@ -110,6 +110,17 @@
 
 Note: Long-context fine-tuning of Llama 3.1 models (32K-131K) is only supported using LoRA.
 
+### Max LoRA rank caps
+
+The `lora_r` parameter defaults to 64 but is capped per model. Setting `lora_r` above the cap returns an error.
+
+| Cap | Models |
+|-----|--------|
+| 16 | Moonshot Kimi K2 family (`Kimi-K2.5`, `Kimi-K2-Thinking`, `Kimi-K2-Instruct-0905`, `Kimi-K2-Instruct`, `Kimi-K2-Base`) |
+| 16 | Z.ai GLM-5, GLM-5.1 |
+| 16 | DeepSeek R1 / R1-0528 / V3 / V3.1 / V3-0324 (and `-Base` variants); R1-Distill variants stay at 64 |
+| 64 | All other LoRA-supported models (default) |
+
 ## Full Fine-tuning
 
 Same models as LoRA, but batch sizes are generally smaller. Key full-fine-tuning-only models:


### PR DESCRIPTION
Syncs `together-fine-tuning` skill with togethercomputer/mintlify-docs#932 (merged).

## Source PR
- togethercomputer/mintlify-docs#932: MOSH-2800: add Max LoRA Rank column to LoRA fine-tuning table

## Triggering doc files
- `docs/fine-tuning-models.mdx`

## Skill changes
- `references/supported-models.md`: added a new **Max LoRA rank caps** table after the LoRA model tables, capturing the per-model `lora_r` ceilings introduced by the new Max LoRA Rank column. Models capped at 16: Moonshot Kimi K2 family, Z.ai GLM-5/5.1, DeepSeek R1/V3 (non-distill) families. All other LoRA-supported models keep the default cap of 64.
- `references/deployment.md`: updated the `lora_r` row in the training-parameters table to note that the rank is capped per model and link to `supported-models.md` for the cap table.

No SKILL.md, scripts, agents, or other references touched.

---
Generated by the Sync Skills Cursor Automation. Please review before merging.
