### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#942

### DIFF
--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -24,6 +24,7 @@
 | Qwen | Qwen3 235B Instruct | `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` | 262,144 | FP8 |
 | Moonshot | Kimi K2.6 | `moonshotai/Kimi-K2.6` | 262,144 | FP4 |
 | DeepSeek | DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` | 512,000 | FP4 |
+| NVIDIA | Nemotron 3 Ultra 550B A55B | `nvidia/nemotron-3-ultra-550b-a55b` | 512,300 | NVFP4 |
 | OpenAI | GPT-OSS 120B | `openai/gpt-oss-120b` | 128,000 | MXFP4 |
 | OpenAI | GPT-OSS 20B | `openai/gpt-oss-20b` | 128,000 | MXFP4 |
 | Z.ai | GLM-5.1 | `zai-org/GLM-5.1` | 202,752 | FP4 |


### PR DESCRIPTION
Syncs the `together-chat-completions` skill with [mintlify-docs#942](https://github.com/togethercomputer/mintlify-docs/pull/942) (_ENG-88891 docs: add NVIDIA Nemotron 3 Ultra 550B A55B to serverless models_), merged at commit `0191185`.

### Triggering doc changes

- `docs/serverless/models.mdx` — added a row to the chat models catalog for NVIDIA Nemotron 3 Ultra 550B A55B (`nvidia/nemotron-3-ultra-550b-a55b`), 512,300 context, NVFP4, \$0.60 / \$0.20 cached / \$3.60 per 1M tokens, with function calling and structured outputs supported.

### Skill changes

- `references/models.md` — appended a new row in the **Full Chat Model Catalog** table for NVIDIA Nemotron 3 Ultra 550B A55B (`nvidia/nemotron-3-ultra-550b-a55b`, context 512,300, quant NVFP4) so the skill's catalog matches the public serverless catalog.

No SKILL.md, scripts, or other references were touched — this is a pure catalog row addition.

---
Generated by the Sync Skills Cursor Automation. Please review before merging.