### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#945

### DIFF
--- a/skills/together-chat-completions/references/reasoning-models.md
+++ b/skills/together-chat-completions/references/reasoning-models.md
@@ -21,6 +21,7 @@
 | GPT-OSS 20B | `openai/gpt-oss-20b` | Adjustable effort | 128K | No |
 | Kimi K2.6 | `moonshotai/Kimi-K2.6` | Hybrid (on by default) | 262K | Yes |
 | MiniMax M2.7 | `MiniMaxAI/MiniMax-M2.7` | Reasoning only | 202K | Yes |
+| Nemotron 3 Ultra 550B A55B | `nvidia/nemotron-3-ultra-550b-a55b` | Hybrid (on by default) | 512K | Yes |
 | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | Hybrid (on by default) | 262K | Yes |
 | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | Hybrid (on by default) | 262K | Yes |
 | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | Hybrid (on by default) | 1M | Yes |
@@ -106,6 +107,7 @@ Hybrid models support `reasoning={"enabled": True/False}` to toggle reasoning on
 - `Qwen/Qwen3.5-9B` (on by default)
 - `Qwen/Qwen3.6-Plus` (on by default)
 - `moonshotai/Kimi-K2.6` (on by default)
+- `nvidia/nemotron-3-ultra-550b-a55b` (on by default)
 - `zai-org/GLM-5.1` (on by default)
 - `zai-org/GLM-5` (on by default)
 
@@ -414,3 +416,8 @@ if (completion?.choices?.[0]?.message?.content) {
 - Use `reasoning_effort` to control depth
 - Set `max_tokens` to ~30,000 with `reasoning_effort="high"`
 - Build Tier 1+ required
+
+### Nemotron 3 Ultra 550B A55B
+- Hybrid reasoning model with 512K context
+- Defaults to high reasoning effort
+- To switch to medium effort, pass `chat_template_kwargs={"medium_effort": True}` instead of `reasoning_effort`


### PR DESCRIPTION
Syncs the `together-chat-completions` skill with [togethercomputer/mintlify-docs#945](https://github.com/togethercomputer/mintlify-docs/pull/945) (DX-647: Add Nemotron 3 Ultra 550B A55B to reasoning page).

### Changed docs files that triggered this sync

- `docs/inference/chat/reasoning.mdx`

### Skill changes

- Added `nvidia/nemotron-3-ultra-550b-a55b` (Hybrid, 512K context, tool calling: yes) to the Full Model Table in `references/reasoning-models.md`.
- Added `nvidia/nemotron-3-ultra-550b-a55b` to the list of hybrid models that support `reasoning={\"enabled\": True/False}`.
- Added a Best Practices entry for Nemotron 3 Ultra 550B A55B noting that it defaults to high reasoning effort and that medium effort is selected via `chat_template_kwargs={\"medium_effort\": True}` (rather than `reasoning_effort`).

---

Generated by the Sync Skills Cursor Automation. Please review before merging.