### PR TITLE
DX-596-together-audio: sync with mintlify-docs#940

### DIFF
--- a/skills/together-audio/references/stt-models.md
+++ b/skills/together-audio/references/stt-models.md
@@ -24,6 +24,8 @@ These models are current in the latest speech-to-text guide and are not listed i
 | Deepgram Nova 3 | `deepgram/deepgram-nova-3` | Dedicated / Reserved | Transcription |
 | Deepgram Nova 3 Multilingual | `deepgram/deepgram-nova-3-multilingual` | Dedicated / Reserved | Transcription |
 | Parakeet TDT 0.6B v3 | `nvidia/parakeet-tdt-0.6b-v3` | Serverless | Realtime, diarization |
+| Nemotron 3 ASR Streaming 0.6B | `nvidia/nemotron-3-asr-streaming-0.6b` | Serverless | Streaming transcription |
+| Nemotron 3.5 ASR Streaming 0.6B | `nvidia/nemotron-3.5-asr-streaming-0.6b` | Serverless | Streaming transcription |
 
 Notes:
 - The `/audio/transcriptions` and `/audio/translations` reference schemas currently enumerate


### PR DESCRIPTION
Syncs the `together-audio` skill with the merged docs PR [togethercomputer/mintlify-docs#940](https://github.com/togethercomputer/mintlify-docs/pull/940) ("DX-546: Sync serverless and dedicated endpoint models").

## Triggering doc changes

- `docs/serverless/models.mdx` — added two new NVIDIA Nemotron ASR streaming models to the serverless audio table.

## Skill changes

- `references/stt-models.md`: added `nvidia/nemotron-3-asr-streaming-0.6b` and `nvidia/nemotron-3.5-asr-streaming-0.6b` to the STT model catalog (Serverless, streaming transcription).

_Generated by the Sync Skills Cursor Automation. Please review before merging._