### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#940

### DIFF
--- a/skills/together-chat-completions/references/function-calling-patterns.md
+++ b/skills/together-chat-completions/references/function-calling-patterns.md
@@ -821,6 +821,6 @@ workflow.
 
 openai/gpt-oss-120b, openai/gpt-oss-20b, moonshotai/Kimi-K2.6,
 zai-org/GLM-5.1, zai-org/GLM-5, MiniMaxAI/MiniMax-M2.7, Qwen/Qwen3.5-397B-A17B,
-Qwen/Qwen3.5-9B, Qwen/Qwen3.6-Plus, Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8,
+Qwen/Qwen3.5-9B, Qwen/Qwen3.6-Plus,
 Qwen/Qwen3-235B-A22B-Instruct-2507-tput, deepseek-ai/DeepSeek-V4-Pro,
 meta-llama/Llama-3.3-70B-Instruct-Turbo, Qwen/Qwen2.5-7B-Instruct-Turbo, google/gemma-4-31B-it

--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -9,7 +9,7 @@
 | Coding Agents | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `deepseek-ai/DeepSeek-V4-Pro`, `MiniMaxAI/MiniMax-M2.7` |
 | Small & Fast | GPT-OSS 20B | `openai/gpt-oss-20b` | `Qwen/Qwen2.5-7B-Instruct-Turbo`, `google/gemma-3n-E4B-it` |
 | Medium General | GPT-OSS 120B | `openai/gpt-oss-120b` | `zai-org/GLM-5` |
-| Function Calling | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` |
+| Function Calling | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `MiniMaxAI/MiniMax-M2.7` |
 | Vision | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | `Qwen/Qwen3.5-9B`, `google/gemma-4-31B-it` |
 
 ## Full Chat Model Catalog

--- a/skills/together-chat-completions/references/structured-outputs.md
+++ b/skills/together-chat-completions/references/structured-outputs.md
@@ -514,7 +514,6 @@ console.log(`Title: ${result.title}`);
 - `MiniMaxAI/MiniMax-M2.7`
 - `Qwen/Qwen3.5-397B-A17B`
 - `Qwen/Qwen3.6-Plus`
-- `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8`
 - `deepseek-ai/DeepSeek-V4-Pro`
 
 ### Additional Supported Models


### PR DESCRIPTION
Syncs the `together-chat-completions` skill with the merged docs PR [togethercomputer/mintlify-docs#940](https://github.com/togethercomputer/mintlify-docs/pull/940) ("DX-546: Sync serverless and dedicated endpoint models").

## Triggering doc changes

- `docs/serverless/models.mdx` — `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` was removed from the serverless chat models table.

## Skill changes

- `references/models.md`: removed `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` from the Function Calling alternatives column and replaced it with `MiniMaxAI/MiniMax-M2.7`.
- `references/function-calling-patterns.md`: dropped `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` from the Supported Models list.
- `references/structured-outputs.md`: dropped `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` from the Top Models (json_schema, json_object, regex) list.

The model is still listed under `together-dedicated-endpoints` as a dedicated-only model; this PR only removes it from the serverless-focused chat-completions skill.

_Generated by the Sync Skills Cursor Automation. Please review before merging._