### PR TITLE
DX-596-together-images: sync with mintlify-docs#940

### DIFF
--- a/skills/together-images/references/models.md
+++ b/skills/together-images/references/models.md
@@ -29,6 +29,7 @@
 | ByteDance | Seedream 3.0 | `ByteDance-Seed/Seedream-3.0` | - |
 | Qwen | Qwen Image | `Qwen/Qwen-Image` | - |
 | Ideogram | Ideogram 3.0 | `ideogram/ideogram-3.0` | - |
+| Ideogram | Ideogram 4.0 | `ideogram/ideogram-4.0` | - |
 | HiDream | HiDream-I1-Full | `HiDream-ai/HiDream-I1-Full` | - |
 | HiDream | HiDream-I1-Dev | `HiDream-ai/HiDream-I1-Dev` | - |
 | HiDream | HiDream-I1-Fast | `HiDream-ai/HiDream-I1-Fast` | - |


### PR DESCRIPTION
Syncs the `together-images` skill with the merged docs PR [togethercomputer/mintlify-docs#940](https://github.com/togethercomputer/mintlify-docs/pull/940) ("DX-546: Sync serverless and dedicated endpoint models").

## Triggering doc changes

- `docs/serverless/models.mdx` — added `ideogram/ideogram-4.0` to the serverless image models table (and removed `xai/grok-imagine-image-pro`, which was never listed in this skill).

## Skill changes

- `references/models.md`: added `ideogram/ideogram-4.0` (Ideogram 4.0) under the Ideogram rows in the Complete Model Table.

_Generated by the Sync Skills Cursor Automation. Please review before merging._