### PR TITLE
DX-596-together-fine-tuning: sync with mintlify-docs#892

### DIFF
--- a/skills/together-fine-tuning/references/data-formats.md
+++ b/skills/together-fine-tuning/references/data-formats.md
@@ -254,14 +254,58 @@ For preference fine-tuning with function calling, the `tools` field goes inside 
 
 ## Data Validation
 
+Validation runs in two stages:
+
+1. **Client-side structural check** (local). Runs by default inside `client.files.upload(..., check=True)` or with `together files check`. Verifies only basic formatting: UTF-8 encoding, one JSON object per line, minimum sample count, and maximum file size. Pass `check=False` to skip (useful for very large files).
+2. **Server-side schema validation** (during ingestion). Runs after upload and performs the full fine-tuning schema check (conversation roles, tool calls, required fields, etc.). The file is only usable for fine-tuning once `processing_status` becomes `COMPLETED`. If validation rejects the dataset, `processing_status` becomes `INVALID_FORMAT` and `validation_report.error` carries a user-facing reason.
+
 ```python
+import time
 from together import Together
 
 client = Together()
 
-# Upload with validation enabled
+# 1. Upload with the local structural check enabled (default).
 file = client.files.upload(file="my_data.jsonl", purpose="fine-tune", check=True)
 print(file.id)  # file-abc123
+
+# 2. Poll until server-side validation finishes before creating a fine-tuning job.
+while True:
+    meta = client.files.retrieve(file.id)
+    if meta.processing_status == "COMPLETED":
+        break
+    if meta.processing_status == "INVALID_FORMAT":
+        # meta.validation_report["error"] carries a user-facing reason.
+        raise ValueError(
+            f"file is not suitable for fine-tuning: {meta.validation_report}"
+        )
+    if meta.processing_status == "FAILED":
+        raise RuntimeError(
+            f"file processing did not complete: {meta.validation_report}"
+        )
+    time.sleep(5)
+```
+
+Treat `processing_status` as the authoritative readiness signal; the `validation_report` schema may evolve. A successful response looks like:
+
+```json
+{
+  "processing_status": "COMPLETED",
+  "validation_report": {"valid": true, "dataset_format": "conversation", "nlines": 7199}
+}
+```
+
+A user-correctable failure looks like:
+
+```json
+{
+  "processing_status": "INVALID_FORMAT",
+  "validation_report": {
+    "valid": false,
+    "error_type": "INVALID_FORMAT",
+    "error": "Line 7: `messages[1]` must contain a `role` field"
+  }
+}
 ```
 
 ```shell
@@ -269,12 +313,14 @@ print(file.id)  # file-abc123
 together files check my_data.jsonl
 together files upload my_data.jsonl
 
-# Upload without format checking
+# Upload without the local structural check
 together files upload my_data.jsonl --no-check
 
-# List and manage files
-together files list
+# Inspect server-side validation status (processing_status / validation_report)
 together files retrieve <FILE-ID>
+
+# List and download files
+together files list
 together files retrieve-content <FILE-ID>
 ```
 

--- a/skills/together-fine-tuning/scripts/dpo_workflow.py
+++ b/skills/together-fine-tuning/scripts/dpo_workflow.py
@@ -26,6 +26,23 @@ from together import Together
 client = Together()
 
 
+def wait_for_file_ready(file_id: str, poll_interval: int = 5) -> None:
+    """Block until server-side fine-tuning validation finishes for ``file_id``."""
+    while True:
+        meta = client.files.retrieve(file_id)
+        if meta.processing_status == "COMPLETED":
+            return
+        if meta.processing_status == "INVALID_FORMAT":
+            raise ValueError(
+                f"file {file_id} is not suitable for fine-tuning: {meta.validation_report}"
+            )
+        if meta.processing_status == "FAILED":
+            raise RuntimeError(
+                f"file {file_id} processing did not complete: {meta.validation_report}"
+            )
+        time.sleep(poll_interval)
+
+
 def sample_sft_data() -> list[dict]:
     """Return a small SFT dataset for the DPO warm-up stage."""
     return [
@@ -159,6 +176,12 @@ def main() -> None:
             dpo_path.unlink(missing_ok=True)
     print(f"SFT file: {sft_file.id}")
     print(f"DPO file: {dpo_file.id}")
+
+    # Wait for server-side validation on both files before starting training.
+    print("Waiting for server-side validation...")
+    wait_for_file_ready(sft_file.id)
+    wait_for_file_ready(dpo_file.id)
+    print("Files ready for fine-tuning.")
 
     # --- 4. Step 1: Run SFT job first ---
     print("\n--- Step 1: SFT Training ---")

--- a/skills/together-fine-tuning/scripts/finetune_workflow.py
+++ b/skills/together-fine-tuning/scripts/finetune_workflow.py
@@ -25,6 +25,27 @@ from together import Together
 client = Together()
 
 
+def wait_for_file_ready(file_id: str, poll_interval: int = 5) -> None:
+    """Block until server-side fine-tuning validation finishes for ``file_id``.
+
+    Raises ``ValueError`` if the dataset is rejected (``INVALID_FORMAT``) and
+    ``RuntimeError`` for any other terminal failure.
+    """
+    while True:
+        meta = client.files.retrieve(file_id)
+        if meta.processing_status == "COMPLETED":
+            return
+        if meta.processing_status == "INVALID_FORMAT":
+            raise ValueError(
+                f"file {file_id} is not suitable for fine-tuning: {meta.validation_report}"
+            )
+        if meta.processing_status == "FAILED":
+            raise RuntimeError(
+                f"file {file_id} processing did not complete: {meta.validation_report}"
+            )
+        time.sleep(poll_interval)
+
+
 def sample_training_data() -> list[dict]:
     """Return a small conversational dataset for demonstration."""
     return [
@@ -128,6 +149,11 @@ def main() -> None:
             data_path.unlink(missing_ok=True)
     file_id = file_response.id
     print(f"Uploaded file: {file_id}")
+
+    # Wait for server-side validation before spending tokens on training.
+    print("Waiting for server-side validation...")
+    wait_for_file_ready(file_id)
+    print("File ready for fine-tuning.")
 
     # --- 3. Create LoRA fine-tuning job ---
     job = client.fine_tuning.create(

--- a/skills/together-fine-tuning/scripts/function_calling_finetune.py
+++ b/skills/together-fine-tuning/scripts/function_calling_finetune.py
@@ -25,6 +25,23 @@ from together import Together
 client = Together()
 
 
+def wait_for_file_ready(file_id: str, poll_interval: int = 5) -> None:
+    """Block until server-side fine-tuning validation finishes for ``file_id``."""
+    while True:
+        meta = client.files.retrieve(file_id)
+        if meta.processing_status == "COMPLETED":
+            return
+        if meta.processing_status == "INVALID_FORMAT":
+            raise ValueError(
+                f"file {file_id} is not suitable for fine-tuning: {meta.validation_report}"
+            )
+        if meta.processing_status == "FAILED":
+            raise RuntimeError(
+                f"file {file_id} processing did not complete: {meta.validation_report}"
+            )
+        time.sleep(poll_interval)
+
+
 def build_tools() -> list[dict]:
     """Return sample tool definitions used by the demo dataset and test prompt."""
     return [
@@ -221,6 +238,11 @@ def main() -> None:
         if data_path is not None:
             data_path.unlink(missing_ok=True)
     print(f"Uploaded file: {file_resp.id}")
+
+    # Wait for server-side validation before starting training.
+    print("Waiting for server-side validation...")
+    wait_for_file_ready(file_resp.id)
+    print("File ready for fine-tuning.")
 
     # --- 3. Start LoRA fine-tuning ---
     job = client.fine_tuning.create(

--- a/skills/together-fine-tuning/scripts/reasoning_finetune.py
+++ b/skills/together-fine-tuning/scripts/reasoning_finetune.py
@@ -33,6 +33,23 @@ from together import Together
 client = Together()
 
 
+def wait_for_file_ready(file_id: str, poll_interval: int = 5) -> None:
+    """Block until server-side fine-tuning validation finishes for ``file_id``."""
+    while True:
+        meta = client.files.retrieve(file_id)
+        if meta.processing_status == "COMPLETED":
+            return
+        if meta.processing_status == "INVALID_FORMAT":
+            raise ValueError(
+                f"file {file_id} is not suitable for fine-tuning: {meta.validation_report}"
+            )
+        if meta.processing_status == "FAILED":
+            raise RuntimeError(
+                f"file {file_id} processing did not complete: {meta.validation_report}"
+            )
+        time.sleep(poll_interval)
+
+
 def sample_training_data() -> list[dict]:
     """Return a small reasoning dataset."""
     return [
@@ -165,6 +182,11 @@ def main() -> None:
         if data_path is not None:
             data_path.unlink(missing_ok=True)
     print(f"Uploaded file: {file_resp.id}")
+
+    # Wait for server-side validation before starting training.
+    print("Waiting for server-side validation...")
+    wait_for_file_ready(file_resp.id)
+    print("File ready for fine-tuning.")
 
     # --- 3. Start LoRA fine-tuning on a reasoning-capable model ---
     job = client.fine_tuning.create(

--- a/skills/together-fine-tuning/scripts/vlm_finetune.py
+++ b/skills/together-fine-tuning/scripts/vlm_finetune.py
@@ -28,6 +28,23 @@ from together import Together
 client = Together()
 
 
+def wait_for_file_ready(file_id: str, poll_interval: int = 5) -> None:
+    """Block until server-side fine-tuning validation finishes for ``file_id``."""
+    while True:
+        meta = client.files.retrieve(file_id)
+        if meta.processing_status == "COMPLETED":
+            return
+        if meta.processing_status == "INVALID_FORMAT":
+            raise ValueError(
+                f"file {file_id} is not suitable for fine-tuning: {meta.validation_report}"
+            )
+        if meta.processing_status == "FAILED":
+            raise RuntimeError(
+                f"file {file_id} processing did not complete: {meta.validation_report}"
+            )
+        time.sleep(poll_interval)
+
+
 def url_to_base64(url: str, mime_type: str = "image/jpeg") -> str:
     """Download an image URL and return a base64 data URI."""
     response = requests.get(url, timeout=60)
@@ -137,6 +154,11 @@ def main() -> None:
         if data_path is not None:
             data_path.unlink(missing_ok=True)
     print(f"Uploaded file: {file_resp.id}")
+
+    # Wait for server-side validation before starting training.
+    print("Waiting for server-side validation...")
+    wait_for_file_ready(file_resp.id)
+    print("File ready for fine-tuning.")
 
     # --- 3. Start VLM LoRA fine-tuning ---
     job = client.fine_tuning.create(


### PR DESCRIPTION
Mirrors [togethercomputer/mintlify-docs#892](https://github.com/togethercomputer/mintlify-docs/pull/892) ("MOSH-2768: update docs with examples of backend file validation").

### Docs changes that triggered this PR

- `docs/fine-tuning-data-preparation.mdx`
- `docs/fine-tuning-quickstart.mdx`

### Skill changes

- `references/data-formats.md`: split validation into a **client-side structural check** (UTF-8 / one-JSON-per-line / min samples / max size) and a **server-side schema validation** stage, and document the new `processing_status` lifecycle (`COMPLETED` / `INVALID_FORMAT` / `FAILED`) along with sample `validation_report` payloads.
- `references/data-formats.md`: refreshed the CLI section to show `together files retrieve <FILE-ID>` as the way to inspect server-side validation status.
- `scripts/finetune_workflow.py`, `scripts/dpo_workflow.py`, `scripts/function_calling_finetune.py`, `scripts/reasoning_finetune.py`, `scripts/vlm_finetune.py`: added a small `wait_for_file_ready(file_id)` helper that polls `client.files.retrieve(...).processing_status` after upload and raises on `INVALID_FORMAT` / `FAILED` before calling `client.fine_tuning.create(...)`, so bad datasets fail fast instead of consuming training time.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.
