### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#954

### DIFF
--- a/skills/together-chat-completions/references/function-calling-patterns.md
+++ b/skills/together-chat-completions/references/function-calling-patterns.md
@@ -386,9 +386,11 @@ print(final.choices[0].message.content)
 
 ```typescript
 import Together from "together-ai";
+import type { ChatCompletionMessageParam } from "together-ai/resources/chat/completions";
+
 const together = new Together();
 
-const messages: any[] = [
+const messages: ChatCompletionMessageParam[] = [
   {
     role: "system",
     content: "You are a helpful assistant that can access external functions.",
@@ -479,7 +481,9 @@ response2 = client.chat.completions.create(
 ```
 
 ```typescript
-const messages: any[] = [
+import type { ChatCompletionMessageParam } from "together-ai/resources/chat/completions";
+
+const messages: ChatCompletionMessageParam[] = [
   { role: "system", content: "You are a travel planning assistant." },
 ];
 


### PR DESCRIPTION
Syncs `together-chat-completions` with the merged docs update in [togethercomputer/mintlify-docs#954](https://github.com/togethercomputer/mintlify-docs/pull/954) ("Update TypeScript chat message docs types").

### Changed docs that triggered this sync

- [`docs/inference/function-calling/agentic.mdx`](https://github.com/togethercomputer/mintlify-docs/blob/c1d9ac2b1cbe7563b829f3f5383979a05700c3b7/docs/inference/function-calling/agentic.mdx) — replaces `CompletionCreateParams.Message[]` (imported from `together-ai/resources/chat/completions.mjs`) with `ChatCompletionMessageParam[]` (imported from `together-ai/resources/chat/completions`) and adds `tool_call_id` on tool-response messages.

### Skill changes

- Updated the TypeScript Multi-step example in `references/function-calling-patterns.md` to type `messages` as `ChatCompletionMessageParam[]` and import the type from `together-ai/resources/chat/completions`, replacing the previous `any[]`.
- Updated the TypeScript Multi-turn example in the same file with the matching typed import and `ChatCompletionMessageParam[]` declaration.
- No changes needed in `scripts/tool_call_loop.ts` or `scripts/reasoning_models.ts` — they already use `ChatCompletionMessageParam` and pass `tool_call_id` on tool-result messages.

Generated by the Sync Skills Cursor Automation. Please review before merging.
