### PR TITLE
DX-596-together-fine-tuning: sync with mintlify-docs#665

### DIFF
--- a/skills/together-fine-tuning/references/data-formats.md
+++ b/skills/together-fine-tuning/references/data-formats.md
@@ -12,6 +12,7 @@
 - [VLM Instruction Format](#vlm-instruction-format)
 - [File Formats](#file-formats)
 - [Loss Masking](#loss-masking)
+- [Sample Weights](#sample-weights)
 - [Data Validation](#data-validation)
 - [Converting Image URLs to Base64](#converting-image-urls-to-base64)
 
@@ -245,12 +246,42 @@ For preference fine-tuning with function calling, the `tools` field goes inside 
 
 ## Loss Masking
 
-- **Conversational format**: Use `weight: 0` on specific messages to exclude from loss
+- **Conversational format**: Use `weight: 0` on specific messages to exclude from loss (only `0` and `1` are accepted on messages; `1` is the default)
 - **`train_on_inputs` parameter**:
   - `"auto"` (default): Framework decides based on format
   - `true`: Train on everything including user messages/prompts
   - `false`: Only train on assistant/completion text
 - **Parquet format**: Set label to -100 for tokens to exclude
+- **Per-sample loss scaling**: Add a top-level `"weight"` to a JSONL sample to multiply the loss for all of its tokens (see [Sample Weights](#sample-weights))
+
+## Sample Weights
+
+All JSONL fine-tuning formats (conversational, instruction, generic text, preference, reasoning, function calling) and all training methods support an optional top-level `"weight"` key on each JSON object. The value is a non-negative float that acts as a loss multiplier on every token in that sample, letting you up- or down-weight individual examples without changing the dataset itself.
+
+- Top-level `weight` is a non-negative float (e.g. `0.1`, `1.0`, `2.5`); `1.0` is the implicit default if omitted
+- Distinct from the per-message `weight` field in conversational data, which only accepts `0` or `1` and gates whether a message's tokens enter the loss at all
+- Sample weights and message weights can be combined in the same file
+- Setting a sample's top-level `weight` to `0` effectively drops it from the loss while still keeping it in the dataset (e.g. for packing statistics)
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "This is a system prompt."},
+    {"role": "user", "content": "Hello, how are you?"},
+    {"role": "assistant", "content": "I'm doing well, thank you! How can I help you?"},
+    {"role": "user", "content": "Can you explain machine learning?", "weight": 0},
+    {"role": "assistant", "content": "Machine learning is...", "weight": 1}
+  ],
+  "weight": 0.9
+}
+{
+  "messages": [
+    {"role": "user", "content": "Can you explain why?"},
+    {"role": "assistant", "content": "I can't."}
+  ],
+  "weight": 0.1
+}
+```
 
 ## Data Validation
 


### PR DESCRIPTION
Syncs `together-fine-tuning` with the merged [togethercomputer/mintlify-docs#665](https://github.com/togethercomputer/mintlify-docs/pull/665) ("MOSH-2291. Sample weights feature -- doc entry").

### Changed docs that triggered this sync
- `docs/fine-tuning-data-preparation.mdx` — adds a new top-level Weighted data section with Message weights and Sample weights subsections

### Skill changes
- `references/data-formats.md`: added a new `## Sample Weights` section describing the optional top-level `"weight"` float on each JSONL sample (loss multiplier across all of its tokens), supported across every JSONL format and training method
- Clarified that the existing per-message `weight` field on conversational data only accepts `0` or `1` (gating), distinct from the new sample-level float `weight` (scaling)
- Cross-linked the new section from the Loss Masking bullets and added it to the references TOC

### Intentionally out of scope
- Wording-only doc tweaks (title case fix, client-vs-server-error rephrasing) that don't change skill behavior
- The `together` → `tg` CLI rename in the docs' File Check section is inconsistent in the upstream PR; left existing `together files …` invocations untouched to avoid a partial CLI rename here

Generated by the Sync Skills Cursor Automation. Please review before merging.