### PR TITLE
DX-596-together-dedicated-endpoints: sync with mintlify-docs#1142

### DIFF
--- a/skills/together-dedicated-endpoints/references/hardware-options.md
+++ b/skills/together-dedicated-endpoints/references/hardware-options.md
@@ -102,9 +102,9 @@ configurations of the same family; for the authoritative live rates always call 
 
 | Hardware ID | Cost/hour |
 |-------------|-----------|
-| `1x_nvidia_h100_80gb_sxm` | $6.49 |
-| `1x_nvidia_h200_140gb_sxm` | $7.89 |
-| `1x_nvidia_b200_180gb_sxm` | $11.95 |
+| `1x_nvidia_h100_80gb_sxm` | $5.40 |
+| `1x_nvidia_h200_140gb_sxm` | $6.60 |
+| `1x_nvidia_b200_180gb_sxm` | $9.00 |
 
 Multi-GPU hardware IDs share the single-GPU suffix, e.g. four H100s use `4x_nvidia_h100_80gb_sxm`.
 Cost scales linearly with the GPU count.


### PR DESCRIPTION
Syncs the [together-dedicated-endpoints](../tree/main/skills/together-dedicated-endpoints) skill with pricing changes from [togethercomputer/mintlify-docs#1142](https://github.com/togethercomputer/mintlify-docs/pull/1142) ("Update pricing for 1x B200 180GB SXM, 1x H100 80GB SXM, 1x H200 140GB SXM").

### Changed docs that triggered this sync

- `docs/dedicated-endpoints/overview.mdx` — updated single-GPU on-demand hardware prices

### Skill changes

- `references/hardware-options.md`: update the "Single-GPU on-demand rates" table to the new prices
  - `1x_nvidia_h100_80gb_sxm`: `$6.49` → `$5.40`
  - `1x_nvidia_h200_140gb_sxm`: `$7.89` → `$6.60`
  - `1x_nvidia_b200_180gb_sxm`: `$11.95` → `$9.00`

No other files touched. `SKILL.md`, scripts, and other references are unaffected.

Generated by the Sync Skills Cursor Automation. Please review before merging.
