### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#927

### DIFF
--- a/skills/together-chat-completions/SKILL.md
+++ b/skills/together-chat-completions/SKILL.md
@@ -35,6 +35,7 @@ clearly offline batch processing, vector retrieval, model training, or infrastru
 - Use `together-fine-tuning` when the user wants to train or adapt a model
 - Use `together-dedicated-endpoints` when the user needs always-on single-tenant hosting
 - Use `together-dedicated-containers` or `together-gpu-clusters` for custom infrastructure
+- For production stock-model workloads that need a defined SLA (committed throughput and reliability) without managing hardware, point users to Together's [provisioned throughput](https://docs.together.ai/docs/inference/provisioned-throughput) tier (reserved PTU capacity, one-month minimum term, contact sales; uses the same chat/completions API surface)
 
 ## Quick Routing
 

--- a/skills/together-chat-completions/references/api-parameters.md
+++ b/skills/together-chat-completions/references/api-parameters.md
@@ -389,7 +389,7 @@ Best practices:
 - plan against the latest headers instead of a hard-coded RPM table
 - keep traffic steady instead of bursty
 - use batch inference for high-volume offline jobs
-- use dedicated endpoints for strict capacity or SLA requirements
+- for strict capacity or SLA requirements, use provisioned throughput (reserved capacity on supported stock models with a defined throughput and reliability SLA, contact sales) or dedicated endpoints (single-tenant GPUs, self-serve)
 
 ## Debug Mode
 


### PR DESCRIPTION
Syncs `together-chat-completions` with [togethercomputer/mintlify-docs#927 "DX-641: Document provisioned throughput"](https://github.com/togethercomputer/mintlify-docs/pull/927), which introduces Together AI's new **provisioned throughput** inference tier (reserved PTU capacity for supported stock models with a defined throughput and reliability SLA, one-month minimum term, sales-only).

## Changed docs that triggered this sync

- `docs/inference/overview.mdx` — reframes inference options as **three** tiers (serverless, provisioned throughput, dedicated endpoints) and notes all three share the same inference API surface.
- `docs/inference/pricing.mdx` — adds a **Provisioned throughput** pricing section ($0.05 per PTU per minute, one-month minimum, model-specific token-to-PTU conversion ratios).
- `docs/serverless/rate-limits.mdx` — adds provisioned throughput to the list of options for workloads that need higher throughput or a defined SLA.

## Skill changes

- `SKILL.md` — Add a **Hand Off** note so agents route production stock-model workloads that need a defined throughput/reliability SLA (without managing hardware) to Together's provisioned throughput tier (contact sales) rather than dedicated endpoints.
- `references/api-parameters.md` — Update the **Rate Limits & Build Tiers** best-practices bullet to list provisioned throughput alongside dedicated endpoints as options for strict capacity or SLA requirements, and note the trade-off (PT = reserved PTU capacity on stock models via sales contract; dedicated = single-tenant GPUs, self-serve).

Generated by the Sync Skills Cursor Automation. Please review before merging.
