### PR TITLE
DX-596-together-dedicated-endpoints: sync with mintlify-docs#927

### DIFF
--- a/skills/together-dedicated-endpoints/SKILL.md
+++ b/skills/together-dedicated-endpoints/SKILL.md
@@ -29,6 +29,7 @@ Typical fits:
 - Use `together-chat-completions` for serverless chat inference
 - Use `together-dedicated-containers` for custom runtimes or nonstandard inference pipelines
 - Use `together-gpu-clusters` for raw infrastructure or cluster orchestration
+- For production **stock-model** workloads that need a defined SLA (committed throughput and reliability) without managing hardware, point users to Together's [provisioned throughput](https://docs.together.ai/docs/inference/provisioned-throughput) tier (reserved PTU capacity, one-month minimum, contact sales). Use dedicated endpoints instead when the user needs to serve a fine-tuned or uploaded model, or wants direct control over hardware, latency, and throughput.
 
 ## Quick Routing
 


### PR DESCRIPTION
Syncs `together-dedicated-endpoints` with [togethercomputer/mintlify-docs#927 "DX-641: Document provisioned throughput"](https://github.com/togethercomputer/mintlify-docs/pull/927), which introduces Together AI's new **provisioned throughput** inference tier (reserved PTU capacity for supported stock models with a defined throughput and reliability SLA, one-month minimum term, sales-only).

## Changed docs that triggered this sync

- `docs/dedicated-endpoints/overview.mdx` — adds a `<Tip>` block directing users who are running a **stock model in production** and want a **defined SLA without managing hardware** to contact sales for provisioned throughput instead of using dedicated endpoints. Dedicated endpoints remain the right fit for fine-tuned or uploaded models and for workloads that need direct control over hardware, latency, and throughput.

## Skill changes

- `SKILL.md` — Add a **Hand Off** bullet that mirrors the docs Tip: route stock-model + production + SLA (no hardware management) users to provisioned throughput (contact sales), and clarify that dedicated endpoints remain the right fit for fine-tuned/uploaded models or when the user needs direct hardware, latency, and throughput control.

Generated by the Sync Skills Cursor Automation. Please review before merging.
