### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#1164

### DIFF
--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -34,7 +34,7 @@
 | Deep Cogito | Cogito v2.1 671B | `deepcogito/cogito-v2-1-671b` | 163,840 | - |
 | Google | Gemma 4 31B IT | `google/gemma-4-31B-it` | 262,144 | FP8 |
 | Google | Gemma 3N E4B | `google/gemma-3n-E4B-it` | 32,768 | FP8 |
-| Liquid AI | LFM2-24B-A2B | `LiquidAI/LFM2-24B-A2B` | 32,768 | - |
+| Liquid AI | LFM2.5-8B-A1B | `LiquidAI/LFM2.5-8B-A1B` | 32,768 | - |
 | Qwen | Qwen 2.5 7B Turbo | `Qwen/Qwen2.5-7B-Instruct-Turbo` | 32,768 | FP8 |
 | Essential AI | Rnj-1 Instruct | `essentialai/rnj-1-instruct` | 32,768 | BF16 |
 


### PR DESCRIPTION
Syncs `together-chat-completions` with [togethercomputer/mintlify-docs#1164](https://github.com/togethercomputer/mintlify-docs/pull/1164) ("DX-546: Add LFM2.5-8B-A1B, Llama-Guard-4-12B to serverless models", merged into `main` at `db4bc4d`).

## Triggering docs changes

- `docs/serverless/models.mdx` — Chat models table: removed `LiquidAI/LFM2-24B-A2B`, added `LiquidAI/LFM2.5-8B-A1B` ($0.03 / $0.12 per 1M in/out, 32,768 ctx).

## Skill changes

- `references/models.md` — Full Chat Model Catalog: replaced the `Liquid AI | LFM2-24B-A2B | `LiquidAI/LFM2-24B-A2B`` row with `Liquid AI | LFM2.5-8B-A1B | `LiquidAI/LFM2.5-8B-A1B`` (32,768 ctx).

No other Liquid AI references exist in this skill, and no scripts, SKILL.md, or other reference files hard-code the previous model ID.

## Not synced

- `together-audio`, `together-images`, `together-video` also match `docs/serverless/models.mdx` in `.skills/sync-map.yaml`, but the change is a chat-model swap and none of those skills reference the affected model.
- The PR title also mentions `Llama-Guard-4-12B`, but no diff for that model landed in this PR; `references/models.md` already lists it under Moderation Models from a previous sync.

Generated by the Sync Skills Cursor Automation. Please review before merging.