### PR TITLE
DX-596-together-gpu-clusters: sync with mintlify-docs#1165

### DIFF
--- a/skills/together-gpu-clusters/references/cluster-management.md
+++ b/skills/together-gpu-clusters/references/cluster-management.md
@@ -334,6 +334,7 @@ During provisioning, nodes undergo automatic tests:
 - **GPU Burn (5 min)** -- stress test for thermal/power issues
 - **Single-Node NCCL** -- GPU-to-GPU communication within a node
 - **Multi-Node NCCL** -- cross-node GPU communication
+- **Storage Performance** -- sequential read/write throughput and data-integrity validation on attached storage volumes
 
 Nodes showing "Tests Failed" are not added to the cluster until repaired.
 
@@ -349,6 +350,9 @@ Nodes showing "Tests Failed" are not added to the cluster until repaired.
 
 **PCIe Performance:**
 - NVBandwidth: CPU-to-GPU, GPU-to-CPU bandwidth, GPU-CPU latency
+
+**Storage:**
+- Storage Performance: `fio` sequential read/write throughput plus a checksummed write/read-back for data-integrity validation against shared and local volumes attached to the cluster. Results include a **Skipped** state (in addition to Passed/Failed) -- on Kubernetes clusters the shared-storage portion reports **Skipped** with message `Shared volume PVC not created` until a shared-volume PVC exists (see the [Storage](#storage) section).
 
 ### Node Repair
 


### PR DESCRIPTION
Syncs with [togethercomputer/mintlify-docs#1165](https://github.com/togethercomputer/mintlify-docs/pull/1165) ("DX-785: docs: add storage performance test documentation").

Changed docs that triggered this sync:
- `docs/health-checks.mdx`

Skill changes:
- Add **Storage Performance** to the automatic acceptance testing list in `references/cluster-management.md` so the reference reflects that new clusters are validated for storage throughput/integrity alongside GPU and NCCL checks.
- Add a new **Storage** subsection under **Available Health Check Tests** describing the `fio`-based sequential read/write + checksummed write/read-back test.
- Document the new **Skipped** result state and the `Shared volume PVC not created` message that Kubernetes clusters get until a shared-volume PVC exists, and point at the existing Storage section for the fix.

Skipped intentionally:
- Pass/fail threshold table values (10 GiB/s read, 5 GiB/s write): the reference doesn't carry the docs' threshold table for other tests either, so keeping it out preserves scope.
- The docs' "Slow data loading -> run Storage Performance + NVBandwidth" tip: the skill reference doesn't have a symptom-to-test triage table.

Generated by the Sync Skills Cursor Automation. Please review before merging.
