### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#1096, #1068

### DIFF
--- a/skills/together-chat-completions/references/function-calling-patterns.md
+++ b/skills/together-chat-completions/references/function-calling-patterns.md
@@ -824,7 +824,7 @@ workflow.
 ## Supported Models
 
 openai/gpt-oss-120b, openai/gpt-oss-20b, moonshotai/Kimi-K2.6,
-zai-org/GLM-5.1, zai-org/GLM-5, MiniMaxAI/MiniMax-M2.7, Qwen/Qwen3.5-397B-A17B,
+zai-org/GLM-5.1, zai-org/GLM-5, MiniMaxAI/MiniMax-M2.7,
 Qwen/Qwen3.5-9B, Qwen/Qwen3.6-Plus,
 Qwen/Qwen3-235B-A22B-Instruct-2507-tput, deepseek-ai/DeepSeek-V4-Pro,
 meta-llama/Llama-3.3-70B-Instruct-Turbo, Qwen/Qwen2.5-7B-Instruct-Turbo, google/gemma-4-31B-it

--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -10,7 +10,7 @@
 | Small & Fast | GPT-OSS 20B | `openai/gpt-oss-20b` | `Qwen/Qwen2.5-7B-Instruct-Turbo`, `google/gemma-3n-E4B-it` |
 | Medium General | GPT-OSS 120B | `openai/gpt-oss-120b` | `zai-org/GLM-5` |
 | Function Calling | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `MiniMaxAI/MiniMax-M2.7` |
-| Vision | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | `Qwen/Qwen3.5-9B`, `google/gemma-4-31B-it` |
+| Vision | Kimi K2.6 | `moonshotai/Kimi-K2.6` | `google/gemma-4-31B-it`, `Qwen/Qwen3.5-9B` |
 
 ## Full Chat Model Catalog
 
@@ -18,7 +18,6 @@
 |-------------|-------|-----------|---------|-------|
 | MiniMax | MiniMax M2.7 | `MiniMaxAI/MiniMax-M2.7` | 202,752 | FP4 |
 | Qwen | Qwen3.7 Max | `Qwen/Qwen3.7-Max` | - | - |
-| Qwen | Qwen3.5 397B A17B | `Qwen/Qwen3.5-397B-A17B` | 262,144 | BF16 |
 | Qwen | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | 1,000,000 | - |
 | Qwen | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | 262,144 | FP8 |
 | Qwen | Qwen3 235B Instruct | `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` | 262,144 | FP8 |
@@ -36,13 +35,12 @@
 | Google | Gemma 3N E4B | `google/gemma-3n-E4B-it` | 32,768 | FP8 |
 | Liquid AI | LFM2.5-8B-A1B | `LiquidAI/LFM2.5-8B-A1B` | 32,768 | - |
 | Qwen | Qwen 2.5 7B Turbo | `Qwen/Qwen2.5-7B-Instruct-Turbo` | 32,768 | FP8 |
-| Essential AI | Rnj-1 Instruct | `essentialai/rnj-1-instruct` | 32,768 | BF16 |
 
 ## Vision Models
 
 | Organization | Model | API String | Context |
 |-------------|-------|-----------|---------|
-| Qwen | Qwen3.5 397B A17B | `Qwen/Qwen3.5-397B-A17B` | 262,144 |
+| Moonshot | Kimi K2.6 | `moonshotai/Kimi-K2.6` | 262,144 |
 | Qwen | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | 262,144 |
 | Google | Gemma 4 31B IT | `google/gemma-4-31B-it` | 262,144 |
 

--- a/skills/together-chat-completions/references/reasoning-models.md
+++ b/skills/together-chat-completions/references/reasoning-models.md
@@ -23,7 +23,6 @@
 | Kimi K2.6 | `moonshotai/Kimi-K2.6` | Hybrid (on by default) | 262K | Yes |
 | MiniMax M2.7 | `MiniMaxAI/MiniMax-M2.7` | Reasoning only | 202K | Yes |
 | Nemotron 3 Ultra 550B A55B | `nvidia/nemotron-3-ultra-550b-a55b` | Hybrid (on by default) | 512K | Yes |
-| Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | Hybrid (on by default) | 262K | Yes |
 | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | Hybrid (on by default) | 262K | Yes |
 | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | Hybrid (on by default) | 1M | Yes |
 
@@ -104,7 +103,6 @@ Hybrid models support `reasoning={"enabled": True/False}` to toggle reasoning on
 
 **Models supporting this parameter:**
 - `deepseek-ai/DeepSeek-V4-Pro` (on by default)
-- `Qwen/Qwen3.5-397B-A17B` (on by default)
 - `Qwen/Qwen3.5-9B` (on by default)
 - `Qwen/Qwen3.6-Plus` (on by default)
 - `moonshotai/Kimi-K2.6` (on by default)
@@ -196,7 +194,7 @@ print(response.choices[0].message.content)
 
 ```python
 response = client.chat.completions.create(
-    model="Qwen/Qwen3.5-397B-A17B",
+    model="Qwen/Qwen3.5-9B",
     messages=[{"role": "user", "content": "Prove that sqrt(2) is irrational."}],
     chat_template_kwargs={"thinking": True},
     stream=True,

--- a/skills/together-chat-completions/references/structured-outputs.md
+++ b/skills/together-chat-completions/references/structured-outputs.md
@@ -512,7 +512,6 @@ console.log(`Title: ${result.title}`);
 - `zai-org/GLM-5.1`
 - `zai-org/GLM-5`
 - `MiniMaxAI/MiniMax-M2.7`
-- `Qwen/Qwen3.5-397B-A17B`
 - `Qwen/Qwen3.6-Plus`
 - `deepseek-ai/DeepSeek-V4-Pro`
 
@@ -538,5 +537,5 @@ console.log(`Title: ${result.title}`);
 3. Use `json_schema` mode when you need guaranteed structure
 4. Use `json_object` for simpler cases where prompt guidance is sufficient
 5. Use `regex` mode for simple constrained outputs (classification, IDs, phone numbers)
-6. Works with vision models (e.g., `Qwen/Qwen3.5-397B-A17B`)
+6. Works with vision models (e.g., `moonshotai/Kimi-K2.6`)
 7. Works with reasoning models (e.g., `deepseek-ai/DeepSeek-V4-Pro`)


### PR DESCRIPTION
Syncs with [togethercomputer/mintlify-docs#1096](https://github.com/togethercomputer/mintlify-docs/pull/1096) and [#1068](https://github.com/togethercomputer/mintlify-docs/pull/1068) (serverless model deprecations/removals). Consolidated into one PR since both edit the same skill's serverless catalog.

Changed docs that triggered this sync:
- `docs/inference/chat/reasoning.mdx` and `docs/serverless/models.mdx` (#1096 — deprecate `Qwen/Qwen3.5-397B-A17B`)
- `docs/serverless/models.mdx` (#1068 — remove `essentialai/rnj-1-instruct`)

Skill changes:
- Retarget the **Vision** recommendation to `moonshotai/Kimi-K2.6` (the current documented vision recommendation) and add it to the Vision Models table.
- Remove `Qwen/Qwen3.5-397B-A17B` everywhere it was presented as a serverless model: chat catalog, vision table, reasoning table, reasoning on-by-default list, structured-outputs support list, and function-calling supported models.
- Repoint two example references off `Qwen/Qwen3.5-397B-A17B` (the `chat_template_kwargs` reasoning snippet → `Qwen/Qwen3.5-9B`; the structured-outputs vision example → `moonshotai/Kimi-K2.6`).
- Remove the `essentialai/rnj-1-instruct` catalog row.

Verification / scope notes:
- Confirmed against the current `main`: `Qwen/Qwen3.5-397B-A17B` and `essentialai/rnj-1-instruct` are absent from `docs/serverless/models.mdx` and the reasoning table.
- Left `zai-org/GLM-5`, `google/gemma-3n-E4B-it`, and `meta-llama/Meta-Llama-3-8B-Instruct-Lite` untouched — all are still in the current serverless catalog/reasoning docs.
- `together-batch-inference` and `together-fine-tuning` still reference `Qwen/Qwen3.5-397B-A17B`; those are out of this PR's sync-map scope (serverless docs don't map to batch, and fine-tuning still supports the model for training).

This is a previously auth-blocked sync now unblocked. Generated by the Sync Skills Cursor Automation. Please review before merging.
