### PR TITLE
DX-596-together-images: sync with mintlify-docs#1113

### DIFF
--- a/skills/together-images/references/models.md
+++ b/skills/together-images/references/models.md
@@ -17,6 +17,7 @@
 | Google | Imagen 4.0 Fast | `google/imagen-4.0-fast` | - |
 | Google | Imagen 4.0 Ultra | `google/imagen-4.0-ultra` | - |
 | Google | Flash Image 2.5 | `google/flash-image-2.5` | - |
+| Google | Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite) | `google/flash-image-3.1-lite` | - |
 | Google | Gemini 3 Pro Image | `google/gemini-3-pro-image` | - |
 | Black Forest Labs | FLUX.2 [pro] | `black-forest-labs/FLUX.2-pro` | - |
 | Black Forest Labs | FLUX.2 [dev] | `black-forest-labs/FLUX.2-dev` | - |


### PR DESCRIPTION
Syncs with [togethercomputer/mintlify-docs#1113](https://github.com/togethercomputer/mintlify-docs/pull/1113) ("DX-546: Add flash-image-3.1-lite, Llama-Guard-4-12B to serverless models").

Changed docs that triggered this sync:
- `docs/serverless/models.mdx`

Skill change (`references/models.md`):
- Add `google/flash-image-3.1-lite` (Gemini 3.1 Flash-Lite Image / Nano Banana 2 Lite) to the Complete Model Table, alongside the existing Google image models.

Verified the model is still present in the current serverless image catalog (`docs/serverless/models.mdx`). The Llama-Guard-4-12B part of #1113 is a moderation/chat model, unrelated to this skill (it already lives in `together-chat-completions`).

This is a previously auth-blocked sync now unblocked. Generated by the Sync Skills Cursor Automation. Please review before merging.
