### PR TITLE
DX-596-together-batch-inference: sync with mintlify-docs#1195

### DIFF
--- a/skills/together-batch-inference/references/api-reference.md
+++ b/skills/together-batch-inference/references/api-reference.md
@@ -250,7 +250,6 @@ Most serverless models support batch processing through the chat completions end
 - `moonshotai/Kimi-K2.6`
 - `Qwen/Qwen3.5-397B-A17B`
 - `zai-org/GLM-5`
-- `zai-org/GLM-5.1`
 
 ## Rate Limits
 


### PR DESCRIPTION
Syncs `together-batch-inference` with [togethercomputer/mintlify-docs#1195](https://github.com/togethercomputer/mintlify-docs/pull/1195) ("MLE-6288 MLE-6285 MLE-6283: docs: deprecate three serverless models on July 10, 2026"), which removed `zai-org/GLM-5.1` from serverless on 2026-07-10.

### Docs changes that triggered this sync
- `docs/inference/batch/overview.mdx` — dropped `zai-org/GLM-5.1` from the list of serverless models that aren't currently available for batch processing.

### Skill changes
- `references/api-reference.md`: removed `zai-org/GLM-5.1` from the "not currently available for batch" bulleted list. The model is no longer on serverless, so it doesn't need to be called out here.

Generated by the Sync Skills Cursor Automation. Please review before merging.