### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#1195

### DIFF
--- a/skills/together-chat-completions/references/function-calling-patterns.md
+++ b/skills/together-chat-completions/references/function-calling-patterns.md
@@ -824,7 +824,6 @@ workflow.
 ## Supported Models
 
 openai/gpt-oss-120b, openai/gpt-oss-20b, moonshotai/Kimi-K2.6,
-zai-org/GLM-5.1, zai-org/GLM-5, MiniMaxAI/MiniMax-M2.7, Qwen/Qwen3.5-397B-A17B,
-Qwen/Qwen3.5-9B, Qwen/Qwen3.6-Plus,
-Qwen/Qwen3-235B-A22B-Instruct-2507-tput, deepseek-ai/DeepSeek-V4-Pro,
+zai-org/GLM-5, MiniMaxAI/MiniMax-M2.7, Qwen/Qwen3.5-397B-A17B,
+Qwen/Qwen3.5-9B, Qwen/Qwen3.6-Plus, deepseek-ai/DeepSeek-V4-Pro,
 meta-llama/Llama-3.3-70B-Instruct-Turbo, Qwen/Qwen2.5-7B-Instruct-Turbo, google/gemma-4-31B-it

--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -6,10 +6,10 @@
 |----------|-------|-----------|-------------|
 | Chat (best) | Kimi K2.6 | `moonshotai/Kimi-K2.6` | `MiniMaxAI/MiniMax-M2.7`, `openai/gpt-oss-120b` |
 | Reasoning | DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` | `moonshotai/Kimi-K2.6`, `Qwen/Qwen3.6-Plus` |
-| Coding Agents | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `deepseek-ai/DeepSeek-V4-Pro`, `MiniMaxAI/MiniMax-M2.7` |
+| Coding Agents | Kimi K2.7 Code | `moonshotai/Kimi-K2.7-Code` | `zai-org/GLM-5.2`, `moonshotai/Kimi-K2.6`, `deepseek-ai/DeepSeek-V4-Pro` |
 | Small & Fast | GPT-OSS 20B | `openai/gpt-oss-20b` | `Qwen/Qwen2.5-7B-Instruct-Turbo`, `google/gemma-3n-E4B-it` |
 | Medium General | GPT-OSS 120B | `openai/gpt-oss-120b` | `zai-org/GLM-5` |
-| Function Calling | GLM-5.1 | `zai-org/GLM-5.1` | `moonshotai/Kimi-K2.6`, `MiniMaxAI/MiniMax-M2.7` |
+| Function Calling | GLM-5.2 | `zai-org/GLM-5.2` | `moonshotai/Kimi-K2.6`, `MiniMaxAI/MiniMax-M2.7` |
 | Vision | Qwen3.5 397B | `Qwen/Qwen3.5-397B-A17B` | `Qwen/Qwen3.5-9B`, `google/gemma-4-31B-it` |
 
 ## Full Chat Model Catalog
@@ -21,16 +21,13 @@
 | Qwen | Qwen3.5 397B A17B | `Qwen/Qwen3.5-397B-A17B` | 262,144 | BF16 |
 | Qwen | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | 1,000,000 | - |
 | Qwen | Qwen3.5 9B | `Qwen/Qwen3.5-9B` | 262,144 | FP8 |
-| Qwen | Qwen3 235B Instruct | `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` | 262,144 | FP8 |
 | Moonshot | Kimi K2.6 | `moonshotai/Kimi-K2.6` | 262,144 | FP4 |
 | DeepSeek | DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` | 512,000 | FP4 |
 | NVIDIA | Nemotron 3 Ultra 550B A55B | `nvidia/nemotron-3-ultra-550b-a55b` | 512,300 | NVFP4 |
 | OpenAI | GPT-OSS 120B | `openai/gpt-oss-120b` | 128,000 | MXFP4 |
 | OpenAI | GPT-OSS 20B | `openai/gpt-oss-20b` | 128,000 | MXFP4 |
-| Z.ai | GLM-5.1 | `zai-org/GLM-5.1` | 202,752 | FP4 |
 | Z.ai | GLM-5 | `zai-org/GLM-5` | 202,752 | FP4 |
 | Meta | Llama 3.3 70B Turbo | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | 131,072 | FP8 |
-| Meta | Llama 3 8B Lite | `meta-llama/Meta-Llama-3-8B-Instruct-Lite` | 8,192 | - |
 | Deep Cogito | Cogito v2.1 671B | `deepcogito/cogito-v2-1-671b` | 163,840 | - |
 | Google | Gemma 4 31B IT | `google/gemma-4-31B-it` | 262,144 | FP8 |
 | Google | Gemma 3N E4B | `google/gemma-3n-E4B-it` | 32,768 | FP8 |

--- a/skills/together-chat-completions/references/reasoning-models.md
+++ b/skills/together-chat-completions/references/reasoning-models.md
@@ -16,7 +16,6 @@
 | Model | API String | Type | Context | Tool Calling |
 |-------|-----------|------|---------|--------------|
 | DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` | Hybrid (on by default) | 512K | Yes |
-| GLM-5.1 | `zai-org/GLM-5.1` | Hybrid (on by default) | 200K | Yes |
 | GLM-5 | `zai-org/GLM-5` | Hybrid (on by default) | 200K | Yes |
 | GPT-OSS 120B | `openai/gpt-oss-120b` | Adjustable effort | 128K | No |
 | GPT-OSS 20B | `openai/gpt-oss-20b` | Adjustable effort | 128K | No |
@@ -109,7 +108,6 @@ Hybrid models support `reasoning={"enabled": True/False}` to toggle reasoning on
 - `Qwen/Qwen3.6-Plus` (on by default)
 - `moonshotai/Kimi-K2.6` (on by default)
 - `nvidia/nemotron-3-ultra-550b-a55b` (on by default)
-- `zai-org/GLM-5.1` (on by default)
 - `zai-org/GLM-5` (on by default)
 
 ### Python -- Enable Reasoning
@@ -242,7 +240,7 @@ response = client.chat.completions.create(
 
 ### Separate reasoning field (most models)
 
-Models like Kimi K2.6, GLM-5.1, DeepSeek-V4-Pro, GPT-OSS, and Qwen3.5 return reasoning in a dedicated
+Models like Kimi K2.6, GLM-5, DeepSeek-V4-Pro, GPT-OSS, and Qwen3.5 return reasoning in a dedicated
 `reasoning` field on the response message or streaming delta.
 
 The field is symmetric: the model returns its chain of thought in `reasoning` (or `delta.reasoning`
@@ -319,7 +317,7 @@ prompt tokens) always live somewhere on `response.usage`, but their **location v
 read both shapes defensively.
 
 - **Reasoning models** (for example `deepseek-ai/DeepSeek-V4-Pro`, `Qwen/Qwen3.6-Plus`,
-  `zai-org/GLM-5.1`) nest them OpenAI-style:
+  `zai-org/GLM-5`) nest them OpenAI-style:
   - `usage.completion_tokens_details.reasoning_tokens`
   - `usage.prompt_tokens_details.cached_tokens`
 - **Some non-reasoning models** (for example `meta-llama/Llama-3.3-70B-Instruct-Turbo`) return
@@ -453,7 +451,7 @@ if (completion?.choices?.[0]?.message?.content) {
 - Supports both reasoning and non-reasoning modes
 - Excels at multi-turn tool calling with reasoning interleaved
 
-### GLM-5.1 / GLM-5
+### GLM-5
 - Thinking is enabled by default
 - Supports Preserved Thinking: set `"clear_thinking": false` in `chat_template_kwargs`
 - Preserved Thinking retains reasoning across turns for better agentic workflows

--- a/skills/together-chat-completions/references/structured-outputs.md
+++ b/skills/together-chat-completions/references/structured-outputs.md
@@ -509,7 +509,6 @@ console.log(`Title: ${result.title}`);
 - `openai/gpt-oss-120b`
 - `openai/gpt-oss-20b`
 - `moonshotai/Kimi-K2.6`
-- `zai-org/GLM-5.1`
 - `zai-org/GLM-5`
 - `MiniMaxAI/MiniMax-M2.7`
 - `Qwen/Qwen3.5-397B-A17B`


### PR DESCRIPTION
Syncs `together-chat-completions` with [togethercomputer/mintlify-docs#1195](https://github.com/togethercomputer/mintlify-docs/pull/1195) ("MLE-6288 MLE-6285 MLE-6283: docs: deprecate three serverless models on July 10, 2026").

The PR deprecated three serverless chat models on 2026-07-10:
- `Qwen/Qwen3-235B-A22B-Instruct-2507-tput`
- `meta-llama/Meta-Llama-3-8B-Instruct-Lite`
- `zai-org/GLM-5.1`

and promoted the remaining Z.ai reasoning/coding model, GLM-5.2, as the new recommended function-calling model in the docs.

### Docs changes that triggered this sync
- `docs/inference/chat/reasoning.mdx` — removed the GLM-5.1 row from the serverless reasoning-model table.
- `docs/inference/function-calling/best-practices.mdx` — swapped the recommended function-calling model from GLM-5.1 to GLM-5.2 in the intro paragraph.
- `docs/inference/recommended-models.mdx` — updated the Reasoning alternative from `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` to `zai-org/GLM-5.2`.
- `docs/serverless/models.mdx` — removed the three deprecated rows from the chat-model catalog.

### Skill changes
- `references/models.md`: dropped the three deprecated rows from the full chat catalog; updated the Coding Agents recommended model to `moonshotai/Kimi-K2.7-Code` and the Function Calling recommended model to `zai-org/GLM-5.2`, matching the current recommended-models page.
- `references/reasoning-models.md`: dropped GLM-5.1 from the full reasoning table and from the `reasoning={"enabled"}` model list; renamed the "GLM-5.1 / GLM-5" best-practices section to "GLM-5"; changed the remaining example model IDs from `zai-org/GLM-5.1` to `zai-org/GLM-5` (still a supported serverless reasoning model).
- `references/function-calling-patterns.md`: dropped `zai-org/GLM-5.1` and `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` from the Supported Models paragraph.
- `references/structured-outputs.md`: dropped `zai-org/GLM-5.1` from the Top Models list.

Generated by the Sync Skills Cursor Automation. Please review before merging.