### PR TITLE
DX-596-together-dedicated-endpoints: sync with mintlify-docs#1215

### DIFF
--- a/skills/together-dedicated-endpoints/SKILL.md
+++ b/skills/together-dedicated-endpoints/SKILL.md
@@ -46,6 +46,8 @@ Typical fits:
   - Read [references/dedicated-models.md](references/dedicated-models.md)
 - **Hardware and sizing choices**
   - Read [references/hardware-options.md](references/hardware-options.md)
+- **LoRA-enabled base model support (target modules, max loaded adapters)**
+  - Read the LoRA-Enabled Base Models section in [references/api-reference.md](references/api-reference.md)
 
 ## Workflow
 

--- a/skills/together-dedicated-endpoints/references/api-reference.md
+++ b/skills/together-dedicated-endpoints/references/api-reference.md
@@ -13,6 +13,7 @@
 - [Upload Model](#upload-model)
 - [List Models](#list-models)
 - [Using the Endpoint](#using-the-endpoint)
+- [LoRA-Enabled Base Models](#lora-enabled-base-models)
 - [Auto-Shutdown](#auto-shutdown)
 - [Speculative Decoding](#speculative-decoding)
 - [Prompt Caching](#prompt-caching)
@@ -459,6 +460,37 @@ curl -X POST "https://api.together.xyz/v1/chat/completions" \
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```
+
+## LoRA-Enabled Base Models
+
+LoRA-enabled dedicated endpoints are available for the base models below. Each adapter uploaded or
+attached to the endpoint must target the same base model and train only from that model's supported
+target modules. `Max loaded adapters` is the maximum number of adapters that can stay attached to a
+single endpoint for that base model.
+
+| Model | Supported target modules | Max loaded adapters |
+|-------|--------------------------|---------------------|
+| `google/gemma-3-270m-it-lora` | `k_proj`, `up_proj`, `o_proj`, `q_proj`, `down_proj`, `v_proj`, `gate_proj` | 16 |
+| `google/gemma-3-27b-it-lora` | `k_proj`, `up_proj`, `o_proj`, `q_proj`, `down_proj`, `v_proj`, `gate_proj` | 16 |
+| `google/gemma-4-31B-it-lora` | `k_proj`, `up_proj`, `o_proj`, `q_proj`, `down_proj`, `v_proj`, `gate_proj` | 16 |
+| `mistralai/Mixtral-8x7B-Instruct-v0.1-FP8-Lora` | `k_proj`, `o_proj`, `q_proj`, `v_proj` | 16 |
+| `meta-llama/Llama-3.3-70B-Instruct-FP8-Lora` | `k_proj`, `up_proj`, `o_proj`, `q_proj`, `down_proj`, `v_proj`, `gate_proj` | 16 |
+| `meta-llama/Llama-4-Scout-17B-16E-Instruct-FP8-Lora` | `k_proj`, `o_proj`, `q_proj`, `v_proj`, `shared_expert.gate_proj`, `shared_expert.up_proj`, `shared_expert.down_proj`, `feed_forward.gate_proj`, `feed_forward.up_proj`, `feed_forward.down_proj` | 16 |
+| `Qwen/Qwen3.5-0.8B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-2B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-4B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-9B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-27B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-35B-A3B-Base-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-35B-A3B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-122B-A10B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.5-397B-A17B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.6-27B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+| `Qwen/Qwen3.6-35B-A3B-Lora` | `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj` † | 5 |
+
+† For the Qwen3.5 and Qwen3.6 models, adapters target the standard attention (`q_proj`, `k_proj`,
+`v_proj`, `o_proj`) and MLP (`gate_proj`, `up_proj`, `down_proj`) projections. Adapters that target
+other layers, such as the vision encoder, may not load for serving.
 
 ## Auto-Shutdown
 


### PR DESCRIPTION
Syncs `together-dedicated-endpoints` with [togethercomputer/mintlify-docs#1215](https://github.com/togethercomputer/mintlify-docs/pull/1215) — *MOSH-3229: list Multi-LoRA supported models and target modules*.

## Changed docs that triggered this sync

- `docs/dedicated-endpoints/lora-adapter.mdx` — adds a "Supported models" section listing LoRA-enabled base models, their supported target modules, and the max loaded adapters per endpoint.

## Skill changes

- Add a new **LoRA-Enabled Base Models** section to `references/api-reference.md` with a table of LoRA-enabled base models, supported LoRA target modules, and max loaded adapters per endpoint (Gemma 3 / Gemma 4, Mixtral-8x7B FP8, Llama 3.3 70B FP8, Llama 4 Scout FP8, and the Qwen 3.5 / Qwen 3.6 dense + MoE family).
- Note that Qwen 3.5 / Qwen 3.6 adapters target only the standard attention (`q_proj`, `k_proj`, `v_proj`, `o_proj`) and MLP (`gate_proj`, `up_proj`, `down_proj`) projections — adapters that target other layers (e.g. the vision encoder) may not load for serving.
- Add the new section to the reference's Contents ToC.
- Add a **Quick Routing** bullet in `SKILL.md` pointing to the new section for questions about target modules and max loaded adapters.

Note: #44 (Multi-LoRA Adapters add/list/remove API surface, from mintlify-docs#878) is still open against the same file. This PR adds a self-contained *Supported models* table so it doesn't depend on #44 landing first; whichever merges first, the other will need a small rebase.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.