### PR TITLE
DX-596-together-gpu-clusters: sync with mintlify-docs#1206

### DIFF
--- a/skills/together-gpu-clusters/references/cluster-management.md
+++ b/skills/together-gpu-clusters/references/cluster-management.md
@@ -354,12 +354,85 @@ Nodes showing "Tests Failed" are not added to the cluster until repaired.
 **Storage:**
 - Storage Performance: `fio` sequential read/write throughput plus a checksummed write/read-back for data-integrity validation against the cluster's shared and local storage tiers.
 
+### Passive Health Checks
+
+Passive checks run continuously on every node and observe real workloads, GPU metrics, and system logs. They have zero impact on running jobs and require no manual action. When a node exhibits one of the conditions below, the system raises a named signal; signals that meet repair criteria generate an auto-repair recommendation.
+
+**GPU and accelerator:**
+
+| Signal | Condition |
+|---|---|
+| `DmesgGpuFallenOffBus` | GPU unreachable on the PCIe bus (hardware or connector failure) |
+| `GpuSmClockThermalThrottle` | Sustained high temperature forces SM clocks down |
+| `DmesgXidError` | NVIDIA driver or hardware Xid fault in the kernel log |
+| `GpuEccDoubleBitError` | Uncorrectable (double-bit) GPU memory error |
+| `GpuRowRemapFailure` | GPU memory row-remap failed; GPU likely needs RMA |
+| `GpuPcieReplayRateHigh` | Degraded PCIe link integrity |
+
+**InfiniBand networking:**
+
+| Signal | Condition |
+|---|---|
+| `IBRailsDownOrDegraded` | Fewer than 8 active 400G IB rails (rail down or negotiated below 400G) |
+| `IBLinkFlapping` | Repeated InfiniBand link-down events on a compute rail |
+
+**Node OS, kernel, and resources:**
+
+| Signal | Condition |
+|---|---|
+| `NpdCperHardwareErrorFatal` | Fatal CPER-reported platform hardware error |
+| `NpdReadonlyFilesystem` | Root or data filesystem remounted read-only |
+| `NpdXfsShutdown` | XFS filesystem shut down after an error |
+| `NpdKernelDeadlock` | Kernel task stuck |
+| `NpdFrequentKubeletRestart` | kubelet restarting repeatedly |
+| `NpdFrequentContainerdRestart` | containerd restarting repeatedly |
+| `NpdFrequentUnregisterNetDevice` | Repeated network device unregister events |
+| `KubeNodeMemoryPressure` | Node under sustained memory pressure |
+| `KubeNodeDiskPressure` | Node under sustained disk pressure |
+| `KubeNodePIDPressure` | Node exhausting available process IDs |
+
+**Scheduler:**
+
+| Signal | Condition |
+|---|---|
+| `SlurmNodeUnavailable` | Slurm marks the node DOWN or DRAIN |
+
+Detection coverage is expanding, and automated recommendations are enabled per cluster; not every signal triggers an automated recommendation today — some raise an internal alert that Together's team reviews first.
+
 ### Node Repair
 
-- **Quick Reprovision**: VM recreated on a random physical node (for software issues)
-- **Migrate to New Host**: New VM on different physical hardware (for hardware failures)
+Auto repair uses three repair actions, ordered lightest to heaviest, plus a warning-only tier. If a lighter action does not clear the issue, it escalates. Every recommendation is reviewed and accepted by the user before a repair runs; training jobs must checkpoint first.
 
-Repair lifecycle: Cordon -> Drain -> Reprovision/Migrate -> Rejoin
+- **Reboot**: Restart the node in place. Fastest recovery; used for recoverable software or transient GPU faults.
+- **Quick Reprovision**: VM recreated on a random physical node (for software issues that persist across reboot).
+- **Migrate to New Host**: New VM on different physical hardware (for hardware failures).
+- **Warning**: Surface an alert for review with no automated repair action.
+
+Repair lifecycle: Cordon -> Drain -> Reboot/Reprovision/Migrate -> Rejoin
+
+**Signal to recommended action:**
+
+| Signal | Action |
+|---|---|
+| `DmesgGpuFallenOffBus` | Migrate to new host |
+| `GpuSmClockThermalThrottle` | Migrate to new host |
+| `GpuPcieReplayRateHigh` | Migrate to new host |
+| `IBRailsDownOrDegraded` | Migrate to new host |
+| `IBLinkFlapping` | Migrate to new host |
+| `NpdCperHardwareErrorFatal` | Quick reprovision |
+| `NpdReadonlyFilesystem` | Quick reprovision |
+| `NpdXfsShutdown` | Quick reprovision |
+| `DmesgXidError` | Reboot (Xid 79 migrates to new host) |
+| `GpuEccDoubleBitError` | Reboot |
+| `GpuRowRemapFailure` | Reboot |
+| `NpdKernelDeadlock` | Reboot |
+| `NpdFrequentKubeletRestart` | Reboot |
+| `NpdFrequentContainerdRestart` | Reboot |
+| `NpdFrequentUnregisterNetDevice` | Reboot |
+| `KubeNodeMemoryPressure` | Reboot |
+| `KubeNodePIDPressure` | Reboot |
+| `KubeNodeDiskPressure` | Warning |
+| `SlurmNodeUnavailable` | Warning |
 
 ### Monitoring Commands
 


### PR DESCRIPTION
Syncs the together-gpu-clusters skill with [togethercomputer/mintlify-docs#1206](https://github.com/togethercomputer/mintlify-docs/pull/1206) ("docs: document passive health check signals and repair actions", merged into main at c32d309e).

## Triggering docs changes
- `docs/health-checks.mdx` — expands Passive Health Checks "Detected failure modes" from 3 unnamed categories to 20 named Prometheus-style signals across 4 groups (GPU/accelerator, InfiniBand, node OS/kernel/resources, scheduler).
- `docs/node-repair.mdx` — expands "Recommended repair actions" to map each passive signal to its repair action; introduces three actions (Reboot, Quick Reprovision, Migrate to New Host) plus a Warning tier. *(Cross-referenced by health-checks.mdx; not a sync-map trigger by itself.)*

## Skill changes (`references/cluster-management.md`)
- Add **Passive Health Checks** subsection listing 20 named signals across GPU/accelerator (6), InfiniBand (2), Node OS/kernel/resources (10), and Scheduler (1), with typical-cause descriptions.
- Rewrite **Node Repair** to cover the three repair actions in escalation order (Reboot -> Quick Reprovision -> Migrate to New Host) plus a Warning-only tier, and note that lighter actions escalate if they don't clear the issue.
- Add **Signal to recommended action** mapping table (all 19 signals with automated actions; Xid 79 is called out as the special case that migrates instead of rebooting).
- Update the repair lifecycle line to include Reboot alongside Reprovision/Migrate.

No changes to `SKILL.md`, scripts, or other reference files — the existing Health Checks section on `cluster-management.md` already had the right home for this content.

Note: the previous auth-blocked backlog entry for mintlify-docs#952 skipped passive checks as "no API surface," but the current docs now surface named signals plus an explicit signal-to-action mapping, which is concrete operational content an agent needs when helping users interpret repair recommendations.

Generated by the Sync Skills Cursor Automation. Please review before merging.