### PR TITLE
DX-596-together-gpu-clusters: sync with mintlify-docs#1231

### DIFF
--- a/skills/together-gpu-clusters/references/cluster-management.md
+++ b/skills/together-gpu-clusters/references/cluster-management.md
@@ -352,7 +352,7 @@ Nodes showing "Tests Failed" are not added to the cluster until repaired.
 - NVBandwidth: CPU-to-GPU, GPU-to-CPU bandwidth, GPU-CPU latency
 
 **Storage:**
-- Storage Performance: `fio` sequential read/write throughput plus a checksummed write/read-back for data-integrity validation against the cluster's shared and local storage tiers.
+- Storage Performance (Preview): `fio` sequential read/write throughput plus a checksummed write/read-back for data-integrity validation against the cluster's shared and local storage tiers. Contact [support](mailto:support@together.ai) for access.
 
 ### Node Repair
 


### PR DESCRIPTION
Syncs `together-gpu-clusters` with the merged docs update in [togethercomputer/mintlify-docs#1231](https://github.com/togethercomputer/mintlify-docs/pull/1231) (*DX-800: Mark Storage Performance health check as Preview*).

### Triggering docs changes

- `docs/health-checks.mdx` — marked the **Storage Performance** active health check as `(Preview)` and added a support-contact note.

### Skill changes

- `references/cluster-management.md`: in the *Available Health Check Tests → Storage* section, renamed the entry to **Storage Performance (Preview)** and added the "Contact support for access" note so agents don't recommend it as generally available.

Left `Automatic Acceptance Testing` untouched: the source doc still lists Storage Performance there without a preview marker, so the current wording remains accurate.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.
