### PR TITLE
DX-596-together-gpu-clusters: sync with mintlify-docs#1180

### DIFF
--- a/skills/together-gpu-clusters/references/cluster-management.md
+++ b/skills/together-gpu-clusters/references/cluster-management.md
@@ -55,15 +55,42 @@ kubectl -n kubernetes-dashboard get secret \
 
 ### SSH Access
 
-SSH keys must be added at `api.together.ai/settings/ssh-key` before cluster creation.
+Two SSH methods are supported. On Slurm clusters with OIDC enabled, pick one from the **SSH access method** selector in the cluster UI sidebar; the choice applies to the head node and all compute nodes. If OIDC is not configured on the cluster, only key-based SSH is available.
+
+| Method | How it works | Requirements |
+|--------|--------------|--------------|
+| **OIDC (Together CLI)** | Browser sign-in that mints a short-lived certificate, executed via `tg beta clusters ssh`. | Together CLI installed (`uv tool install "together[cli]"`, 2.20+, Python 3.10+). Choose a login name when prompted in the cluster UI. No SSH key required. |
+| **Key-based** | Standard `ssh -J` proxy jump through the cluster's bastion. | SSH public key uploaded at `api.together.ai/settings/ssh-key` before cluster creation. |
+
+The cluster UI's **Copy SSH command** (worker/compute) and **Copy head node SSH command** (Slurm login) buttons emit a command shaped for the selected method.
+
+**Key-based commands:**
 
 ```shell
-# Direct SSH to worker nodes
-ssh <node-hostname>.cloud.together.ai
+# Worker node (Kubernetes) or Slurm compute node
+ssh -J <LOGIN>@ssh.<CLUSTER_ID>.<REGION>.cloud.together.ai <LOGIN>@<NODE_HOSTNAME>
 
 # Slurm login node
-ssh <username>@slurm-login
+ssh -J <LOGIN>@ssh.<CLUSTER_ID>.<REGION>.cloud.together.ai <LOGIN>@slurm-login
 ```
+
+**OIDC commands (Together CLI):**
+
+```shell
+# Worker node (Kubernetes) or Slurm compute node
+tg beta clusters ssh https://dex.<REGION>.cloud.together.ai/<CLUSTER_ID> \
+  --login <LOGIN> --host <NODE_HOSTNAME>
+
+# Slurm login node (host defaults to the head node)
+tg beta clusters ssh https://dex.<REGION>.cloud.together.ai/<CLUSTER_ID> --login <LOGIN>
+```
+
+If the CLI was previously installed with `pip`, migrate to the `uv`-managed install before using OIDC SSH: `pip uninstall together` and reinstall with `uv tool install "together[cli]"`.
+
+**Slurm hostnames:**
+
+- Compute nodes: `<NODE_NAME>.slurm-compute.slurm` (e.g., `gpu-dp-hmqnh-nwlnj.slurm-compute.slurm`)
+- Login node: always `slurm-login`
 
 ### Slurm Commands
 


### PR DESCRIPTION
Sync `together-gpu-clusters` with [togethercomputer/mintlify-docs#1180](https://github.com/togethercomputer/mintlify-docs/pull/1180) ("docs: document Slurm OIDC and key-based SSH access methods").

## Changed docs (that triggered this sync)

- `docs/gpu-clusters-management.mdx` — new SSH access method selector, OIDC `tg beta clusters ssh` examples, corrected Slurm compute-node hostname.
- `docs/gpu-clusters-quickstart.mdx` — updated Slurm prerequisites: OIDC vs key-based SSH.

(`reference/cli/clusters.mdx` and `reference/cli/getting-started.mdx` were also touched in the source PR but are not mapped to any skill in `.skills/sync-map.yaml`, so no skill-side CLI reference edits are made here.)

## Skill changes

- `references/cluster-management.md` — rewrote the **SSH Access** subsection:
  - Replaced the single generic SSH block with an **OIDC vs key-based** method table so agents route users through the cluster-details **SSH access method** selector on Slurm clusters (falls back to key-based when OIDC is not configured).
  - Added OIDC command shapes for both worker/compute and Slurm head nodes, including the DEX URL, `--login`, and `--host` flags.
  - Updated key-based examples to the `ssh -J` proxy-jump form the cluster UI now emits.
  - Noted the CLI 2.20+ / Python 3.10+ requirement and the pip → uv migration step for OIDC SSH.
  - Corrected the Slurm compute-node hostname suffix from `.slurm.pod` to `.slurm-compute.slurm`.

Validated locally with `python3 scripts/quick_validate.py skills/together-gpu-clusters` (OK, 0 errors) and `python3 scripts/quality_check.py` (no warnings).

---

_Generated by the Sync Skills Cursor Automation. Please review before merging._
