### PR TITLE
DX-596-together-dedicated-endpoints: sync with mintlify-docs#991

### DIFF
--- a/skills/together-dedicated-endpoints/SKILL.md
+++ b/skills/together-dedicated-endpoints/SKILL.md
@@ -1,81 +1,105 @@
 ---
 name: together-dedicated-endpoints
-description: "Single-tenant GPU endpoints on Together AI with autoscaling and no rate limits. Deploy fine-tuned or uploaded models, size hardware, and manage endpoint lifecycle. Reach for it whenever the user needs predictable always-on hosting rather than serverless inference, custom containers, or raw clusters."
+description: "Single-tenant GPU endpoints on Together AI with autoscaling and no rate limits. Deploy fine-tuned or uploaded models, upload LoRA adapters, size hardware, and manage endpoint lifecycle with the v2 dedicated model inference (DMI) resource model — endpoints, deployments, and configs — plus traffic splits, A/B tests, shadow experiments, and metric-gated rollouts. Reach for it whenever the user needs predictable always-on hosting rather than serverless inference, custom containers, or raw clusters."
 ---
 
 # Together Dedicated Endpoints
 
 ## Overview
 
-Use dedicated endpoints for managed single-tenant model hosting with predictable performance and
-no shared serverless pool.
+Dedicated endpoints serve a model on hardware reserved for one project, priced per GPU-minute and shared with nothing else. Two generations are live:
+
+- **v2 (default): dedicated model inference (DMI)**. Splits an endpoint from the deployment that runs the model, letting one endpoint host several deployments and shift traffic between them. Adds traffic splits, A/B tests, shadow experiments, metric-gated rollouts, and CLI-first management under `tg beta`.
+- **v1 (legacy, supported through end of 2026)**. One model per endpoint. Managed by the top-level `together endpoints` CLI and `client.endpoints.*` SDK. Kept alive for existing endpoints; new deployments should target v2.
 
 Typical fits:
 
-- production inference with stable latency
-- fine-tuned model hosting
-- uploaded custom model hosting
-- autoscaled model APIs
+- Production inference with stable latency and no shared-fleet rate limits
+- Fine-tuned or uploaded custom model hosting (including LoRA adapters via v2 uploads)
+- Autoscaled model APIs where per-GPU-minute economics beat per-token serverless
+- Shipping a candidate deployment behind an A/B test, shadow experiment, or gated rollout
 
 ## When This Skill Wins
 
-- The user needs always-on or single-tenant hosting
-- The model is supported for dedicated deployment
-- Fine-tuned or uploaded models must be served as endpoints
-- Hardware, scaling, or idle-time settings need explicit control
+- The user needs always-on or single-tenant hosting.
+- The model is supported for dedicated deployment (or is a fine-tune of a supported base).
+- Hardware, autoscaling metric, or replica bounds need explicit control.
+- The workflow includes safe rollouts, live A/B comparison, or shadow-traffic evaluation.
 
 ## Hand Off To Another Skill
 
-- Use `together-chat-completions` for serverless chat inference
-- Use `together-dedicated-containers` for custom runtimes or nonstandard inference pipelines
-- Use `together-gpu-clusters` for raw infrastructure or cluster orchestration
+- Use `together-chat-completions` for serverless chat inference.
+- Use `together-dedicated-containers` for custom runtimes or nonstandard inference pipelines.
+- Use `together-gpu-clusters` for raw infrastructure or cluster orchestration.
 - For production **stock-model** workloads that need a defined SLA (committed throughput and reliability) without managing hardware, point users to Together's [provisioned throughput](https://docs.together.ai/docs/inference/provisioned-throughput) tier (reserved PTU capacity, one-month minimum, contact sales). Use dedicated endpoints instead when the user needs to serve a fine-tuned or uploaded model, or wants direct control over hardware, latency, and throughput.
 
 ## Quick Routing
 
-- **Create and manage a standard endpoint**
-  - Start with [scripts/manage_endpoint.py](scripts/manage_endpoint.py) or [scripts/manage_endpoint.ts](scripts/manage_endpoint.ts)
-  - Read [references/api-reference.md](references/api-reference.md)
-- **Lifecycle tuning or troubleshooting**
-  - Read [references/api-reference.md](references/api-reference.md)
-- **Deploy a fine-tuned model**
-  - Start with [scripts/deploy_finetuned.py](scripts/deploy_finetuned.py)
-  - Read [references/dedicated-models.md](references/dedicated-models.md)
-- **Upload and deploy a custom model**
-  - Start with [scripts/upload_custom_model.py](scripts/upload_custom_model.py)
-  - Read [references/dedicated-models.md](references/dedicated-models.md)
+- **Deploy a supported model on v2 (one-shot)**
+  - Use `tg beta endpoints deploy <model> --endpoint <name>` (creates endpoint + deployment + traffic split).
+  - Read [references/api-reference.md](references/api-reference.md).
+- **Manage v2 endpoints, deployments, and configs individually**
+  - Start with [scripts/deploy_v2.sh](scripts/deploy_v2.sh).
+  - Read [references/api-reference.md](references/api-reference.md).
+- **Upload a fine-tuned model or LoRA adapter (v2)**
+  - Use `tg beta models create` then `tg beta models upload` or `tg beta models remote-uploads create`.
+  - Read [references/models-and-configs.md](references/models-and-configs.md).
+- **Split traffic, run an A/B test, shadow experiment, or gated rollout (v2 only)**
+  - Read [references/traffic-routing.md](references/traffic-routing.md).
+- **Manage a v1 endpoint (legacy)**
+  - Start with [scripts/manage_endpoint.py](scripts/manage_endpoint.py) or [scripts/manage_endpoint.ts](scripts/manage_endpoint.ts).
+  - Read the v1 API section at the end of [references/api-reference.md](references/api-reference.md).
 - **Hardware and sizing choices**
-  - Read [references/hardware-options.md](references/hardware-options.md)
+  - Read [references/hardware-options.md](references/hardware-options.md).
 
-## Workflow
+## Workflow (v2)
 
-1. Confirm that the task needs dedicated hosting instead of serverless or containers.
-2. Verify model eligibility and inspect available hardware.
-3. Create the endpoint with explicit scaling and timeout settings.
-4. Wait for readiness before sending inference traffic.
-5. Stop or delete the endpoint when the workload no longer needs to run.
+1. Confirm the task needs dedicated hosting rather than serverless or containers.
+2. Pick a supported model (or upload one), and select a deployment profile (config).
+3. Run `tg beta endpoints deploy <model>` to create the endpoint, attach a deployment, and route all traffic in one step. Set `--min-replicas` and `--max-replicas` for the autoscaling policy.
+4. Poll deployment status until it reaches `DEPLOYMENT_STATE_READY`, then send inference to `https://api-inference.together.ai/v1` with `model = "<project_slug>/<endpoint_name>"`.
+5. Delete or scale to zero when the workload is done. `tg beta endpoints rm <id> --force` smart-deletes endpoint, deployment, A/B, or shadow resources by ID prefix.
 
 ## High-Signal Rules
 
-- Python scripts require the Together v2 SDK (`together>=2.0.0`). If the user is on an older version, they must upgrade first: `uv pip install --upgrade "together>=2.0.0"`.
-- Model eligibility and hardware availability are gating constraints; check them early.
-- Endpoint management uses endpoint IDs, while inference usually uses the endpoint name as `model`.
-- Autoscaling, auto-shutdown, prompt caching, and speculative decoding materially affect operations and cost.
-- For custom or fine-tuned models, do not skip the intermediate verification steps before deployment.
+- **v2 CLI requires Together CLI 2.24.0+**. Install with `uv tool install "together[cli]"` (or `pip install together`). Every v2 management command lives under `tg beta`.
+- **v2 SDK surface (`client.beta.endpoints.*`, `client.beta.models.*`) is still being published**. Prefer the CLI or raw HTTP for v2 automation until the SDK stabilizes; the v1 SDK (`client.endpoints.*`) continues to work only against v1 endpoints.
+- **Project scope matters**. `tg beta` and the v2 management API read the project from `TOGETHER_PROJECT_ID` or the `--project` flag; without either, the CLI falls back to the project associated with your API key and prompts for confirmation in interactive shells.
+- **Model eligibility and instance-type headroom gate every deployment**. Check them early with `tg beta models public --product DEDICATED` and by reading the `regions[].headroom` field on `/v2/public/inference-instance-types`.
+- **A ready deployment doesn't serve traffic on its own**. In v2 a deployment only receives requests once it's in the endpoint's traffic split with a non-zero weight. `tg beta endpoints deploy` handles this for the first deployment; add subsequent ones with `tg beta endpoints update <dep_id> --traffic-weight <n>`.
+- **Endpoint (`ep_...`) is the URL; deployment (`dep_...`) runs the model**. The management API takes IDs; the inference `model` parameter is the endpoint string `"<project_slug>/<endpoint_name>"`.
+- **Stopping a deployment means both replica bounds to `0`**. `min:0` requires `max:0`. Scaled-to-zero deployments don't restart on requests; raise both bounds to `1` or more to bring them back (paying a cold start).
+- **Autoscaling metric target units differ**. Latency metrics (`ttft`, `decoding_speed`, `e2e_latency`) are milliseconds. Percentages (`gpu_utilization`, `token_utilization`, `cache_hit_rate`) are 0–100. Averages (`inflight_requests`, `throughput_per_replica`) are per-replica. Streaming-only metrics require `"stream": true` on requests.
+- **Uploads must be fine-tuned variants of a supported base architecture**. `baseModelId` (a `ml_...` model ID) is required on `tg beta models create`; the architecture `arch_...` ID is not accepted.
+- **Rollout metric gates are canary-only** and require live traffic on the target. Blue-green and rolling strategies reject a `metrics` block.
+- **Prompt caching is on by default** on dedicated model inference — no headers, no toggles.
 
 ## Resource Map
 
-- **API reference**: [references/api-reference.md](references/api-reference.md)
-- **Operational controls and troubleshooting**: [references/api-reference.md](references/api-reference.md)
-- **Dedicated model guide**: [references/dedicated-models.md](references/dedicated-models.md)
-- **Hardware guide**: [references/hardware-options.md](references/hardware-options.md)
-- **Python endpoint lifecycle**: [scripts/manage_endpoint.py](scripts/manage_endpoint.py)
-- **TypeScript endpoint lifecycle**: [scripts/manage_endpoint.ts](scripts/manage_endpoint.ts)
-- **Fine-tuned deployment**: [scripts/deploy_finetuned.py](scripts/deploy_finetuned.py)
-- **Custom model upload and deployment**: [scripts/upload_custom_model.py](scripts/upload_custom_model.py)
+- **v2 API reference and CLI commands**: [references/api-reference.md](references/api-reference.md)
+- **Traffic routing (splits, A/B, shadow, rollouts)**: [references/traffic-routing.md](references/traffic-routing.md)
+- **Models, configs, and deployment profiles**: [references/models-and-configs.md](references/models-and-configs.md)
+- **Dedicated model list**: [references/dedicated-models.md](references/dedicated-models.md)
+- **Hardware, instance types, and pricing**: [references/hardware-options.md](references/hardware-options.md)
+- **v2 CLI walkthrough (deploy, scale, split, tear down)**: [scripts/deploy_v2.sh](scripts/deploy_v2.sh)
+- **v1 Python endpoint lifecycle (legacy)**: [scripts/manage_endpoint.py](scripts/manage_endpoint.py)
+- **v1 TypeScript endpoint lifecycle (legacy)**: [scripts/manage_endpoint.ts](scripts/manage_endpoint.ts)
+- **v1 fine-tuned deployment (legacy)**: [scripts/deploy_finetuned.py](scripts/deploy_finetuned.py)
+- **v1 custom model upload and deployment (legacy)**: [scripts/upload_custom_model.py](scripts/upload_custom_model.py)
 
 ## Official Docs
 
-- [Dedicated Endpoints](https://docs.together.ai/docs/dedicated-inference)
-- [Endpoints API](https://docs.together.ai/reference/createendpoint)
-- [Upload and Deploy Custom Models](https://docs.together.ai/docs/custom-models)
+- [Dedicated model inference (v2 overview)](https://docs.together.ai/docs/dedicated-endpoints/overview)
+- [Concepts (endpoints, deployments, configs, profiles)](https://docs.together.ai/docs/dedicated-endpoints/concepts)
+- [Migrate from v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1)
+- [Quickstart](https://docs.together.ai/docs/dedicated-endpoints/quickstart)
+- [Manage deployments](https://docs.together.ai/docs/dedicated-endpoints/manage)
+- [Configure autoscaling](https://docs.together.ai/docs/dedicated-endpoints/scaling)
+- [Route traffic](https://docs.together.ai/docs/dedicated-endpoints/route-traffic)
+- [A/B tests](https://docs.together.ai/docs/dedicated-endpoints/ab-tests)
+- [Shadow experiments](https://docs.together.ai/docs/dedicated-endpoints/shadow-experiments)
+- [Rollouts](https://docs.together.ai/docs/dedicated-endpoints/rollouts)
+- [Upload a fine-tuned model](https://docs.together.ai/docs/dedicated-endpoints/custom-models)
+- [Upload a LoRA adapter](https://docs.together.ai/docs/dedicated-endpoints/adapter)
+- [Pricing](https://docs.together.ai/docs/dedicated-endpoints/pricing)
+- [v1 (legacy) overview](https://docs.together.ai/docs/dedicated-endpoints/v1/overview)

--- a/skills/together-dedicated-endpoints/references/api-reference.md
+++ b/skills/together-dedicated-endpoints/references/api-reference.md
@@ -1,43 +1,560 @@
-# Dedicated Endpoints API Reference
+# Dedicated Model Inference API Reference
+
+Together's dedicated endpoints ship in two generations:
+
+- **v2 (default): dedicated model inference (DMI)**. Endpoint / deployment / config resource model,
+  managed under `tg beta` and the `/v2` management API. All new capabilities land here.
+- **v1 (legacy)**. Single-model endpoints managed under `tg endpoints` and `client.endpoints.*`.
+  Supported through the end of 2026; migrate with [migrate-from-v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1).
+
 ## Contents
 
-- [Endpoints](#endpoints)
-- [Create Endpoint](#create-endpoint)
-- [Get Endpoint](#get-endpoint)
-- [List Endpoints](#list-endpoints)
-- [Endpoint States](#endpoint-states)
-- [Update Endpoint](#update-endpoint)
-- [Start / Stop](#start-stop)
-- [Delete](#delete)
-- [List Hardware](#list-hardware)
-- [Upload Model](#upload-model)
-- [List Models](#list-models)
-- [Using the Endpoint](#using-the-endpoint)
-- [Auto-Shutdown](#auto-shutdown)
-- [Speculative Decoding](#speculative-decoding)
-- [Prompt Caching](#prompt-caching)
-- [Availability Zones](#availability-zones)
-- [Troubleshooting](#troubleshooting)
-- [CLI Reference](#cli-reference)
-- [Endpoint Response Object](#endpoint-response-object)
+- [Resource Model (v2)](#resource-model-v2)
+- [Resource IDs](#resource-ids)
+- [CLI installation](#cli-installation)
+- [Project scope](#project-scope)
+- [Endpoints (v2)](#endpoints-v2)
+- [Deployments (v2)](#deployments-v2)
+- [Deployment states](#deployment-states)
+- [Autoscaling (v2)](#autoscaling-v2)
+- [Configs and profiles (v2)](#configs-and-profiles-v2)
+- [Instance types and capacity](#instance-types-and-capacity)
+- [Model uploads (v2)](#model-uploads-v2)
+- [LoRA adapter uploads (v2)](#lora-adapter-uploads-v2)
+- [Sending inference (v1 and v2)](#sending-inference-v1-and-v2)
+- [Prompt caching](#prompt-caching)
+- [Observability](#observability)
+- [Troubleshooting (v2)](#troubleshooting-v2)
+- [Smart delete (v2)](#smart-delete-v2)
+- [v1 legacy API](#v1-legacy-api)
 
+## Resource Model (v2)
 
-## Endpoints
+DMI is built from six components:
+
+- **Project (`proj_...`)**: Organizational boundary. Every API key is scoped to a project, and every
+  resource lives inside it.
+- **Model (`ml_...`)**: A concrete set of weights. One base architecture can have several weights,
+  one per quantization. Together-supported models are visible from every project; uploads and
+  fine-tunes belong to your project.
+- **Config (`cr_...`)**: A published, immutable serving spec that fixes engine, parallelism,
+  hardware, and optimization for one model weight. Often lives in a Together platform project rather
+  than yours.
+- **Endpoint (`ep_...`)**: A logical grouping of deployments and a stable inference URL. Always
+  lives in your project. The endpoint string used for inference is `<project_slug>/<endpoint_name>`.
+- **Deployment (`dep_...`)**: Binds a model + config to an endpoint with an autoscaling policy. This
+  is what actually runs replicas and serves traffic. One endpoint can host several deployments.
+- **Replica**: An instance of the model running on its own hardware. Replicas serve requests in
+  parallel and can be autoscaled.
+
+A **deployment profile** is a certified pairing of one model weight with one config, exposed in the
+public catalog. When a model has one profile the CLI picks it automatically; when it has several,
+pass `--config <cr_...>`.
+
+Request routing: request → endpoint → traffic split → (optional A/B re-sample) → deployment →
+replica. See [traffic-routing.md](traffic-routing.md).
+
+## Resource IDs
+
+| Resource | ID format | Notes |
+| --- | --- | --- |
+| Project | `proj_...` | Retrieve with `tg whoami` or from the [settings page](https://api.together.ai/settings/organization/~current/projects). |
+| Model | `ml_...` | Same format for supported models and your uploads. |
+| Model revision | `rv_...` | An immutable snapshot of a model. |
+| Architecture | `arch_...` | Top-level catalog entry for a model family. |
+| Config | `cr_...` | Config revision. Immutable; new revisions get new IDs. |
+| Endpoint | `ep_...` | Inference name is `<project_slug>/<endpoint_name>`. |
+| Deployment | `dep_...` | Management name is `<project_slug>/<endpoint_name>/<deployment_name>`. |
+| A/B experiment | `abx_...` | See [traffic-routing.md](traffic-routing.md#ab-tests-abx_). |
+| Shadow experiment | `exp_...` | See [traffic-routing.md](traffic-routing.md#shadow-experiments-exp_). |
+| Rollout | `rol_...` | See [traffic-routing.md](traffic-routing.md#rollouts-rol_). |
+| Model upload job | `job_...` | Remote-upload job for `tg beta models remote-uploads`. |
+| Instance type | `1xnvidia-h100-80gb` (etc.) | Deployable unit of hardware; per-hour price attaches to it. |
+
+## CLI installation
+
+The v2 CLI requires Together CLI `2.24.0` or later:
+
+```bash
+uv tool install "together[cli]"           # or: pip install together
+tg --version                              # verify 2.24.0+
+```
+
+All v2 management commands live under `tg beta`. The Python SDK is imported as `together` (v2 SDK
+uses `client.beta.endpoints.*` and `client.beta.models.*` namespaces; some surfaces are still being
+published — prefer the CLI or raw HTTP for automation until the SDK stabilizes).
+
+## Project scope
+
+Every v2 call resolves against a single project:
+
+```bash
+export TOGETHER_PROJECT_ID=proj_abc123    # explicit
+tg beta endpoints ls --project proj_abc123 # per-command override
+tg whoami                                  # inspect the resolved project
+```
+
+Without either, `tg beta` uses the project associated with your API key and prompts for
+confirmation. In CI, agents, or headless environments always set `TOGETHER_PROJECT_ID` or
+`--project`.
+
+## Endpoints (v2)
+
+### Deploy in one step
+
+`tg beta endpoints deploy` bundles endpoint creation, deployment attachment, and traffic-split
+setup:
+
+```bash
+tg beta endpoints deploy google/gemma-4-E4B-it \
+  --endpoint my-endpoint \
+  --min-replicas 1 --max-replicas 2
+```
+
+Positional argument is the model (public name, private name, `ml_...`, or resolved model path).
+`--endpoint` accepts either an existing endpoint's name/ID or a new name. When the model has more
+than one deployment profile, the command errors and prints available profiles; re-run with
+`--config <cr_...>`.
+
+### Deploy flags
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `MODEL` | Yes | Positional. Model to deploy. |
+| `--endpoint` | Yes | Existing endpoint name/ID or new name. |
+| `--config` | No | Config ID (`cr_...`). Required when the model has multiple profiles. |
+| `--deployment-name` | No | Defaults to a combo of the endpoint + model names. |
+| `--min-replicas` / `--max-replicas` | No | Default `1` each. |
+| `--scaling-metric` / `--scaling-target` | No | Set together. See [Autoscaling](#autoscaling-v2). |
+| `--scaling-percentile` | No | `p50`, `p90`, `p95` (default), or `p99`. Latency metrics only. |
+| `--scale-up-window` / `--scale-down-window` | No | Stabilization windows. Defaults: `0s` up, `5m` down. |
+| `--enable-lora` | No | Boot the deployment's multi-LoRA kernel so adapters hot-load after deploy. Cannot be changed on a running deployment. |
+| `--project` | No | Override `TOGETHER_PROJECT_ID`. |
+
+### Create an empty endpoint
+
+The CLI has no standalone create-endpoint command. Use the SDK or API:
+
+```python
+from together import Together
+
+client = Together()
+project_id = client.whoami().project_id
+
+endpoint = client.beta.endpoints.create(
+    project_id=project_id,
+    name="my-endpoint",
+)
+print(endpoint)
+```
+
+### List and inspect
+
+```bash
+tg beta endpoints ls                       # all endpoints in the project
+tg beta endpoints ls --limit 100 --after <cursor>
+tg beta endpoints ls --org                 # org-scoped
+tg beta endpoints ls --public              # public
+tg beta endpoints get ep_abc123            # one endpoint, with each deployment's state and replica counts
+```
+
+List responses paginate with `next_cursor`; pass it as `--after` on the next request.
+
+### Update
+
+```bash
+tg beta endpoints update dep_abc123 --min-replicas 2 --max-replicas 4
+tg beta endpoints update dep_abc123 --traffic-weight 70
+```
+
+Pass a **deployment ID** (`dep_...`); the CLI resolves the parent endpoint automatically.
+
+## Deployments (v2)
+
+A deployment binds one model + one config to an endpoint and controls autoscaling. Create with
+`tg beta endpoints deploy`, or via the SDK/API to add a second deployment to an existing endpoint.
+
+### Create (via API)
+
+```python
+deployment = client.beta.endpoints.deployments.create(
+    endpoint_id,
+    project_id=project_id,
+    name="prod",
+    model="projects/proj_abc123/models/ml_abc123",
+    config="projects/proj_abc123/configs/cr_abc123",
+    autoscaling={"min_replicas": 1, "max_replicas": 2},
+)
+```
+
+List and retrieve responses return a flat deployment object whose `model` and `config` resource
+names can be copied straight into a new create request:
+
+```json
+{
+  "id": "dep_abc123",
+  "projectId": "proj_abc123",
+  "endpointId": "ep_abc123",
+  "name": "your-project-slug/my-endpoint/my-deployment",
+  "model": "projects/proj_abc123/models/ml_abc123/revisions/rv_abc",
+  "config": "projects/proj_abc123/configs/cr_abc123",
+  "autoscaling": {"minReplicas": 1, "maxReplicas": 2},
+  "hardware": "1xnvidia-h100-80gb",
+  "trafficMode": "TRAFFIC_MODE_LIVE",
+  "desiredReplicas": 1,
+  "status": {"state": "DEPLOYMENT_STATE_PROVISIONING", "scheduledReplicas": 0, "readyReplicas": 0, "message": "Scheduling replicas"}
+}
+```
+
+After creating a deployment, [route traffic](traffic-routing.md) to it before it can serve
+requests.
+
+### Poll status
+
+```bash
+tg beta endpoints get ep_abc123            # each deployment's state + replica counts
+```
+
+Retrieve a single deployment from the SDK to read the full `status`:
+
+```python
+deployment = client.beta.endpoints.deployments.retrieve(
+    "dep_abc123",
+    project_id=project_id,
+    endpoint_id="ep_abc123",
+)
+print(deployment.status.state, deployment.status.message)
+```
+
+Progress fields:
+
+| Field | Description |
+| --- | --- |
+| `desiredReplicas` | Target replica count from autoscaling. |
+| `status.scheduledReplicas` | Replicas the scheduler has placed on clusters. |
+| `status.readyReplicas` | Replicas actively serving traffic. |
+| `status.message` | Human-readable stage or cause. |
+| `status.state` | See below. |
+
+### Scale, stop, restart
+
+```bash
+tg beta endpoints update dep_abc123 --min-replicas 2 --max-replicas 4    # rescale
+tg beta endpoints update dep_abc123 --min-replicas 0 --max-replicas 0    # stop (drains, then DEPLOYMENT_STATE_STOPPED)
+tg beta endpoints update dep_abc123 --min-replicas 1 --max-replicas 2    # restart
+```
+
+Rules:
+
+- `min:0` requires `max:0`. `min:0` with a positive `max` is rejected.
+- Setting `min == max` fixes the deployment size and disables autoscaling.
+- A stopped deployment doesn't restart on requests. Raise both bounds to `1` or more.
+
+## Deployment states
+
+`status.state` is returned as the fully-qualified enum (for example
+`DEPLOYMENT_STATE_READY`). Short names below.
+
+| State | Description |
+| --- | --- |
+| `PROVISIONING` | Scheduler is placing replicas. |
+| `SCALING` | Replicas starting or draining. |
+| `READY` | All replicas healthy and serving. Still needs a non-zero traffic weight to receive requests. |
+| `DEGRADED` | Below requested capacity or blocked by a transient issue. Usually self-heals. |
+| `STOPPING` | Draining after a stop request. Settles to `STOPPED` (or `FAILED` on teardown failure). |
+| `STOPPED` | Zero replicas. Not billing, not serving. |
+| `FAILED` | Terminal. Read `status.message` for cause. A deployment that never reaches `READY` within six hours after starting is marked `FAILED`. |
+
+## Autoscaling (v2)
+
+Set replica bounds and (optionally) a scaling metric on `deploy` or `update`:
+
+```bash
+tg beta endpoints deploy zai-org/GLM-5.2 \
+  --endpoint my-glm-endpoint \
+  --min-replicas 1 --max-replicas 4 \
+  --scaling-metric gpu_utilization \
+  --scaling-target 70
+```
+
+With bounds but no metric, DMI applies the default: `inflight_requests` with target `8`.
+
+### Scaling metrics
+
+| `--scaling-metric` | Target unit | Notes |
+| --- | --- | --- |
+| `inflight_requests` | Concurrent requests per replica (average) | Default. Leading indicator. |
+| `gpu_utilization` | Percentage (0–100), averaged across replicas | Cost-first. |
+| `token_utilization` | Percentage (0–100) | KV-cache utilization. |
+| `cache_hit_rate` | Percentage (0–100) | Prompt-cache hit rate. Specialist. |
+| `throughput_per_replica` | Tokens/s per replica | Streaming-only. |
+| `ttft` | Milliseconds, percentile across deployment | Streaming-only. |
+| `decoding_speed` | Milliseconds per output token | Streaming-only. |
+| `e2e_latency` | Milliseconds, percentile across deployment | Streaming + non-streaming. |
+
+Rules:
+
+- Streaming-only metrics require `"stream": true` on requests.
+- Latency-metric targets are read at the percentile in `--scaling-percentile` (default `p95`).
+- Percentages are per-replica averages; averages are per-replica; latencies are fleet-wide percentiles.
+
+### Timing
+
+Each scaling evaluation runs roughly every 60 seconds:
+
+1. Stabilization windows: `--scale-up-window` (default `0s`) and `--scale-down-window` (default `5m`).
+2. Rate limits (fleet defaults, not overridable):
+
+   | Direction | Limit | Period |
+   | --- | --- | --- |
+   | Scale up | Smaller of +100% or +4 replicas | 15s |
+   | Scale down | Smaller of −25% or −1 replica | 60s |
+
+3. Clamp to `[minReplicas, maxReplicas]`.
+
+## Configs and profiles (v2)
+
+List configs published for a model with:
+
+```bash
+tg beta models configs ml_CbJNwQC2ZqCU2iFT3mrCh
+```
+
+Response shape (abbreviated):
+
+```json
+{
+  "data": [
+    {
+      "id": "cr_CbeuemXsU8yGStQvBBEgY",
+      "referenceModel": "projects/proj_weights/models/ml_CbJ9yCnij7A47b1xkpioB",
+      "referenceModelId": "ml_CbJ9yCnij7A47b1xkpioB",
+      "projectId": "proj_abc123",
+      "selectors": [
+        {"key": "accelerator_count", "value": "1"},
+        {"key": "accelerator_type",  "value": "nvidia-h100-80gb"},
+        {"key": "optimization",      "value": "balanced"},
+        {"key": "topology",          "value": "aggregated"}
+      ]
+    }
+  ]
+}
+```
+
+Selectors:
+
+| Selector | Description | Example |
+| --- | --- | --- |
+| `accelerator_type` | GPU SKU. | `nvidia-h100-80gb` |
+| `accelerator_count` | Replica GPU count. | `1`, `2`, `4`, `8` |
+| `optimization` | Serving profile. | `balanced`, `throughput`, `latency` |
+| `topology` | Layout across GPUs. | `aggregated` |
+
+Pass the config `id` as a resource name (`projects/{project_id}/configs/{config_revision_id}`) in
+the `config` field of a create-deployment request, using the config's `projectId` (often a Together
+platform project, not yours). Configs are immutable; new revisions get new `cr_...` IDs. Speculative
+decoding and other decoding optimizations are declared inside the config — you cannot toggle them
+on the deployment.
+
+## Instance types and capacity
+
+A config's `accelerator_type` + `accelerator_count` maps to a deployable instance type (for example
+`1xnvidia-h100-80gb`). Query the public catalog:
+
+```bash
+curl -s -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  https://api.together.ai/v2/public/inference-instance-types
+```
+
+Each instance type lists `regions`, and each region reports `headroom` — a best-effort hint of how
+many more replicas of that type currently fit. `headroom = N` with `RELATION_GTE` means at least N
+units are free; the actual number may be higher. Use it to pick a region with capacity before you
+deploy. Per-hour pricing lives in [hardware-options.md](hardware-options.md).
+
+## Model uploads (v2)
+
+Uploads must be fine-tuned variants of a supported base architecture. See
+[models-and-configs.md](models-and-configs.md) for a fuller walkthrough. Summary:
+
+```bash
+# 1. Create the record. Save the returned model id (ml_...).
+tg beta models create gemma-4-31b-it \
+  --base-model ml_CbJNwQC2ZqCU2iFT3mrCh
+
+# 2a. Upload from your machine.
+tg beta models upload ml_abc123 ./path/to/model-dir
+
+# 2b. Or upload from Hugging Face / S3.
+tg beta models remote-uploads create ml_abc123 \
+  --from https://huggingface.co/your-org/your-repo \
+  --token hf_your_token
+
+# 3. Poll the remote-upload job until REMOTE_UPLOAD_STATUS_SUCCEEDED.
+tg beta models remote-uploads retrieve job_abc123
+tg beta models ls-files ml_abc123           # confirm files landed
+
+# 4. Deploy it like any base model.
+tg beta endpoints deploy ml_abc123 \
+  --endpoint my-custom-model \
+  --config cr_CbzGdmn14t3HYrXXitmKa
+```
+
+Create request fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | Yes | Inference-addressable name (readable, not a Hugging Face repo ID). |
+| `base_model_id` | Yes | `baseModelId` (`ml_...`) of the supported base. Not the architecture `arch_...`. |
+| `description` | No | Description in the project catalog. |
+| `type` | No | `model` (default) or `adapter`. Fixed at create; can't be changed. |
+
+## LoRA adapter uploads (v2)
+
+Same create/upload/deploy flow as full models, with `--type adapter` on create. The adapter must
+target a supported base model that Together AI serves for dedicated inference:
+
+```bash
+tg beta models create my-stsb-lora \
+  --type adapter \
+  --base-model ml_CbJNwQC2ZqCU2iFT3mrCh
+
+tg beta models remote-uploads create ml_abc123 \
+  --from https://huggingface.co/your-org/your-adapter \
+  --token hf_your_token
+
+tg beta endpoints deploy ml_abc123 \
+  --endpoint my-adapter \
+  --config cr_CbzGdmn14t3HYrXXitmKa
+```
+
+Adapter naming tip: strip any org prefix from the repo name (for example use `glue_stsb`, not
+`predibase/glue_stsb`) — the server prepends your project slug and doubled slugs can't be renamed.
+
+Adapter files: the source must contain `adapter_config.json` and `adapter_model.safetensors`, at the
+root of the S3 archive or the Hugging Face repo. Presigned S3 URLs must have at least 100 minutes of
+validity.
+
+## Sending inference (v1 and v2)
+
+Dedicated model inference is served at `https://api-inference.together.ai`. There is no CLI for
+inference; use the SDK or curl and point the base URL at that host. Pass the endpoint string
+(`<project_slug>/<endpoint_name>`) as `model`:
+
+```python
+from together import Together
+
+client = Together(base_url="https://api-inference.together.ai/v1")
+
+response = client.chat.completions.create(
+    model="your-project-slug/my-endpoint",
+    messages=[{"role": "user", "content": "What is 2+2?"}],
+    max_tokens=512,
+)
+print(response.choices[0].message.content)
+```
+
+```bash
+curl -s -X POST https://api-inference.together.ai/v1/chat/completions \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "your-project-slug/my-endpoint",
+    "messages": [{"role": "user", "content": "What is 2+2?"}],
+    "max_tokens": 512
+  }'
+```
+
+Everything the underlying model supports — function calling, structured outputs, streaming, vision —
+works the same on DMI as on serverless.
+
+## Prompt caching
+
+Prompt caching is enabled by default on dedicated model inference. There is no header, parameter,
+or account toggle. Requests that share a prompt prefix and route to the same replica reuse the
+cached prefix.
+
+To keep cache hits from scattering across replicas, set `prompt_cache_key` on requests that share a
+prefix. The endpoint uses `prompt_cache_key` first, then `user`, then a content-derived key to pin
+requests to the same deployment.
+
+## Observability
+
+Every endpoint exposes:
+
+- **Analytics dashboard** at [api.together.ai/endpoints](https://api.together.ai/endpoints) with
+  per-endpoint latency, throughput, replica count, and utilization.
+- **Events feed** merging endpoint- and deployment-scoped events. List via
+  `client.beta.endpoints.list_events(endpoint_id, project_id=..., limit=50)`. Filters:
+  `types`, `min_level`, `source_kinds`, `since`, `until`, `subject_id`, `deployment_ids`, `after`.
+  `limit` defaults to 50, max 500.
+- **Prometheus-compatible metrics endpoint (beta)** at
+  `GET https://o11y-de2-metrics.cloud.together.ai/organizations/{org_id}/metrics`. Authenticate with
+  your API key as a bearer token. Grouped by edge / router / worker; histograms exposed as
+  `_bucket`, `_sum`, `_count`. See the [monitoring docs](https://docs.together.ai/docs/dedicated-endpoints/monitoring)
+  for the full metric list.
+
+## Troubleshooting (v2)
+
+- **`endpoint_not_configured` (HTTP 400) though the deployment is `READY`** — Deployment isn't in
+  the endpoint's traffic split (or has weight `0`). Set a non-zero weight with
+  `tg beta endpoints update <dep_id> --traffic-weight <n>`.
+- **`DEGRADED` with `Cannot place replicas: insufficient GPU capacity`** — Fleet is constrained.
+  Compare `status.scheduledReplicas` to `desiredReplicas`. Ask for fewer replicas or a smaller
+  config.
+- **`DEGRADED` with `Startup stalled` or `Not ready`** — A placed replica is still booting or hit a
+  startup failure. Read the detail in `status.message`.
+- **`FAILED` with `Timed out waiting for readiness`** — No replica provisioned within six hours.
+  Restart to begin a fresh budget.
+- **Deploy fails with `the model has no revisions to deploy`** — Model record exists but has no
+  uploaded weights yet.
+- **Deployment delete fails with `the deployment is referenced by an endpoint's traffic split and
+  cannot be deleted`** — Drop the traffic weight to `0` first, or use `tg beta endpoints rm dep_...`
+  which auto-detaches.
+- **Model delete fails with `the model is referenced by a live deployment`** — Stop the deployment,
+  wait for `STOPPED`, delete the deployment, then delete the model.
+
+## Smart delete (v2)
+
+`tg beta endpoints rm` resolves the resource by ID prefix and does the right thing:
+
+| ID prefix | Effect |
+| --- | --- |
+| `ep_` | Deletes the endpoint (must have no deployments unless `--force`). |
+| `dep_` | Auto-detaches from the traffic split and any experiments, then deletes the deployment (must be stopped). |
+| `abx_` | Deletes an A/B experiment. Returns traffic to the control. |
+| `exp_` | Deletes a shadow experiment. Cascade-deletes its targets. |
+
+Rollout IDs (`rol_...`) are not accepted by `rm`; use the SDK's `rollouts.delete`.
+
+Teardown order for a full endpoint:
+
+1. Scale each deployment to `0/0`. Wait for `DEPLOYMENT_STATE_STOPPED`.
+2. `tg beta endpoints rm dep_...` for each deployment (or drop traffic weight to `0` if using the API).
+3. `tg beta endpoints rm ep_...`.
+
+Pass `--force` to `rm ep_...` to delete an endpoint that still has deployments.
+
+## v1 legacy API
+
+v1 remains available for existing endpoints and is supported through the end of 2026. New endpoints
+should target v2. The tables below cover the v1 surface.
+
+### v1 endpoint operations
 
 | Method | Path | Description |
-|--------|------|-------------|
-| `POST /endpoints` | Create endpoint | Deploy a new dedicated endpoint |
-| `GET /endpoints` | List endpoints | List all endpoints |
-| `GET /endpoints/{id}` | Get endpoint | Get endpoint details |
-| `PATCH /endpoints/{id}` | Update endpoint | Update config/scaling |
-| `DELETE /endpoints/{id}` | Delete endpoint | Remove endpoint |
-| `GET /hardware` | List hardware | Available hardware configs |
-| `POST /models` | Upload model | Upload custom model |
-| `GET /models` | List models | List available models |
+| --- | --- | --- |
+| `POST /endpoints` | Create endpoint (v1) |
+| `GET /endpoints` | List endpoints |
+| `GET /endpoints/{id}` | Get endpoint |
+| `PATCH /endpoints/{id}` | Update config / scaling / state |
+| `DELETE /endpoints/{id}` | Delete endpoint |
+| `GET /hardware` | List v1 hardware |
+| `POST /models` | Upload custom model (v1) |
+| `GET /models` | List v1 models |
 
-Base URL: `https://api.together.xyz/v1`
+Base URL: `https://api.together.xyz/v1`.
 
-## Create Endpoint
+### v1 create example
 
 ```python
 endpoint = client.endpoints.create(
@@ -47,40 +564,9 @@ endpoint = client.endpoints.create(
     autoscaling={"min_replicas": 1, "max_replicas": 3},
     inactive_timeout=60,  # minutes, 0 or None to disable
 )
-print(endpoint.id)  # endpoint-abc123
 ```
 
-```typescript
-import Together from "together-ai";
-const together = new Together();
-
-const endpoint = await together.endpoints.create({
-  model: "Qwen/Qwen3.5-9B-FP8",
-  hardware: "1x_nvidia_h100_80gb_sxm",
-  autoscaling: {
-    min_replicas: 1,
-    max_replicas: 3,
-  },
-});
-console.log(endpoint.id);
-```
-
-```shell
-curl -X POST "https://api.together.xyz/v1/endpoints" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "Qwen/Qwen3.5-9B-FP8",
-    "hardware": "1x_nvidia_h100_80gb_sxm",
-    "display_name": "My Endpoint",
-    "autoscaling": {
-      "min_replicas": 1,
-      "max_replicas": 3
-    }
-  }'
-```
-
-```shell
+```bash
 together endpoints create \
   --model Qwen/Qwen3.5-9B-FP8 \
   --hardware 1x_nvidia_h100_80gb_sxm \
@@ -89,252 +575,45 @@ together endpoints create \
   --wait
 ```
 
-### Request Body
+### v1 request fields
 
 | Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `model` | string | Yes | - | Model to deploy |
-| `hardware` | string | Yes | - | Hardware config ID |
-| `autoscaling` | object | Yes | - | `{min_replicas, max_replicas}` |
-| `display_name` | string | No | - | Human-readable name |
-| `disable_speculative_decoding` | bool | No | false | Disable spec decoding |
-| `state` | string | No | `"STARTED"` | `"STARTED"` or `"STOPPED"` |
-| `inactive_timeout` | int/null | No | 60 | Minutes before auto-stop (0/null disables) |
-| `availability_zone` | string | No | - | Preferred zone |
+| --- | --- | --- | --- | --- |
+| `model` | string | Yes | — | Model to deploy. |
+| `hardware` | string | Yes | — | Hardware config ID (v1 underscore format). |
+| `autoscaling` | object | Yes | — | `{min_replicas, max_replicas}`. |
+| `display_name` | string | No | — | Human-readable name. |
+| `disable_speculative_decoding` | bool | No | `false` | Disable speculative decoding. |
+| `state` | string | No | `"STARTED"` | `"STARTED"` or `"STOPPED"`. |
+| `inactive_timeout` | int/null | No | 60 | Minutes before auto-stop (0/null disables). |
+| `availability_zone` | string | No | — | Preferred zone. |
 
-## Get Endpoint
-
-```python
-endpoint = client.endpoints.retrieve("endpoint-abc123")
-print(endpoint.state)
-```
-
-```typescript
-const endpoint = await together.endpoints.retrieve("endpoint-abc123");
-console.log(endpoint);
-```
-
-```shell
-curl "https://api.together.xyz/v1/endpoints/endpoint-abc123" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json"
-```
-
-```shell
-together endpoints retrieve <ENDPOINT_ID>
-together endpoints retrieve <ENDPOINT_ID> --json
-```
-
-## List Endpoints
-
-```python
-response = client.endpoints.list()
-for ep in response.data:
-    print(ep.id)
-```
-
-```typescript
-const endpoints = await together.endpoints.list();
-for (const endpoint of endpoints.data) {
-  console.log(endpoint);
-}
-```
-
-```shell
-curl "https://api.together.xyz/v1/endpoints" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json"
-
-# Filter by type and ownership
-curl "https://api.together.xyz/v1/endpoints?type=dedicated&mine=true" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json"
-```
-
-```shell
-together endpoints list --mine
-together endpoints list --type dedicated
-together endpoints list --mine --type dedicated --usage-type on-demand
-together endpoints list --json
-```
-
-### Query Parameters
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `type` | string | Filter by `dedicated` or `serverless` |
-| `usage_type` | string | Filter by `on-demand` or `reserved` |
-| `mine` | boolean | Only endpoints owned by the caller |
-
-## Endpoint States
+### v1 endpoint states
 
 | State | Description |
-|-------|-------------|
-| `PENDING` | Waiting for resources |
-| `STARTING` | Initializing |
-| `STARTED` | Running, accepting requests |
-| `STOPPING` | Shutting down |
-| `STOPPED` | Not running |
-| `ERROR` | Failed |
+| --- | --- |
+| `PENDING` | Waiting for resources. |
+| `STARTING` | Initializing. |
+| `STARTED` | Running, accepting requests. |
+| `STOPPING` | Shutting down. |
+| `STOPPED` | Not running. |
+| `ERROR` | Failed. |
 
-## Update Endpoint
-
-```python
-client.endpoints.update(
-    "endpoint-abc123",
-    autoscaling={"min_replicas": 2, "max_replicas": 5},
-    display_name="Updated Name",
-)
-```
-
-```typescript
-await together.endpoints.update("endpoint-abc123", {
-  autoscaling: { min_replicas: 2, max_replicas: 5 },
-  display_name: "Updated Name",
-});
-```
-
-```shell
-curl -X PATCH "https://api.together.xyz/v1/endpoints/endpoint-abc123" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "autoscaling": {
-      "min_replicas": 2,
-      "max_replicas": 5
-    },
-    "display_name": "Updated Name"
-  }'
-```
-
-```shell
-together endpoints update --min-replicas 2 --max-replicas 5 <ENDPOINT_ID>
-together endpoints update --display-name "Updated Name" <ENDPOINT_ID>
-```
-
-### Updatable Fields
-
-- `display_name`
-- `state` (`"STARTED"` or `"STOPPED"`)
-- `autoscaling`
-- `inactive_timeout`
-
-## Start / Stop
+### v1 start / stop / delete
 
 ```python
-# Start
 client.endpoints.update("endpoint-abc123", state="STARTED")
-
-# Stop
 client.endpoints.update("endpoint-abc123", state="STOPPED")
-```
-
-```typescript
-// Start
-await together.endpoints.update("endpoint-abc123", { state: "STARTED" });
-
-// Stop
-await together.endpoints.update("endpoint-abc123", { state: "STOPPED" });
-```
-
-```shell
-# Start
-curl -X PATCH "https://api.together.xyz/v1/endpoints/endpoint-abc123" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"state": "STARTED"}'
-
-# Stop
-curl -X PATCH "https://api.together.xyz/v1/endpoints/endpoint-abc123" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"state": "STOPPED"}'
-```
-
-```shell
-together endpoints start <ENDPOINT_ID>
-together endpoints start <ENDPOINT_ID> --wait
-together endpoints stop <ENDPOINT_ID>
-together endpoints stop <ENDPOINT_ID> --wait
-```
-
-## Delete
-
-Returns HTTP 204 on success.
-
-```python
 client.endpoints.delete("endpoint-abc123")
 ```
 
-```typescript
-await together.endpoints.delete("endpoint-abc123");
+```bash
+together endpoints start   <ID>
+together endpoints stop    <ID>
+together endpoints delete  <ID>
 ```
 
-```shell
-curl -X DELETE "https://api.together.xyz/v1/endpoints/endpoint-abc123" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY"
-```
-
-```shell
-together endpoints delete <ENDPOINT_ID>
-```
-
-## List Hardware
-
-```python
-response = client.endpoints.list_hardware()
-for hw in response.data:
-    print(hw.id)
-
-# Filter by model
-response = client.endpoints.list_hardware(model="Qwen/Qwen3.5-9B-FP8")
-for hw in response.data:
-    price = hw.pricing.cents_per_minute if hw.pricing else "N/A"
-    print(f"{hw.id}: {hw.specs.gpu_count}x {hw.specs.gpu_type} @ {price}c/min")
-```
-
-```typescript
-const hardware = await together.endpoints.listHardware();
-console.log(hardware);
-```
-
-```shell
-curl "https://api.together.xyz/v1/hardware" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json"
-
-# Filter by model
-curl "https://api.together.xyz/v1/hardware?model=Qwen/Qwen3.5-9B-FP8" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json"
-```
-
-```shell
-together endpoints hardware
-together endpoints hardware --model Qwen/Qwen3.5-9B-FP8
-together endpoints hardware --model Qwen/Qwen3.5-9B-FP8 --available
-together endpoints hardware --model Qwen/Qwen3.5-9B-FP8 --json
-```
-
-### Hardware Response Object
-
-```json
-{
-  "object": "hardware",
-  "id": "1x_nvidia_h100_80gb_sxm",
-  "pricing": { "cents_per_minute": 10.82 },
-  "specs": {
-    "gpu_type": "h100",
-    "gpu_link": "sxm",
-    "gpu_memory": 80,
-    "gpu_count": 1
-  },
-  "availability": { "status": "available" },
-  "updated_at": "2025-01-15T14:30:00Z"
-}
-```
-
-## Upload Model
+### v1 upload
 
 ```python
 response = client.models.upload(
@@ -345,239 +624,36 @@ response = client.models.upload(
 print(response.data.job_id)
 ```
 
-```typescript
-const response = await client.models.upload({
-  model_name: "my-custom-model",
-  model_source: "https://huggingface.co/your-org/your-model",
-});
-console.log(response);
-```
-
-```shell
-curl -X POST "https://api.together.xyz/v1/models" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model_name": "my-custom-model",
-    "model_source": "https://huggingface.co/your-org/your-model",
-    "hf_token": "hf_..."
-  }'
-```
-
-```shell
+```bash
 together models upload \
   --model-name my-custom-model \
   --model-source https://huggingface.co/your-org/your-model \
   --hf-token $HF_TOKEN
 ```
 
-### Upload Parameters
+Job status:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `model_name` | string | Yes | Name for the uploaded model |
-| `model_source` | string | Yes | Hugging Face repo URL or S3 presigned URL |
-| `model_type` | string | No | `"model"` (default) or `"adapter"` |
-| `hf_token` | string | No | Hugging Face token for private repos |
-| `description` | string | No | Model description |
-| `base_model` | string | No | Base model for adapters (serverless) |
-| `lora_model` | string | No | LoRA pool for adapters (dedicated) |
-
-### Upload Response
-
-```json
-{
-  "data": {
-    "job_id": "job-b641db51-38e8-40f2-90a0-5353aeda6f21",
-    "model_name": "devuser/my-custom-model",
-    "model_source": "remote_archive"
-  },
-  "message": "job created"
-}
-```
-
-### Check Upload Status
-
-```shell
+```bash
 curl "https://api.together.xyz/v1/jobs/<job_id>" \
   -H "Authorization: Bearer $TOGETHER_API_KEY"
 ```
 
-## List Models
+### v1 auto-shutdown
 
-```python
-models = client.models.list()
-for model in models:
-    print(model.id)
-```
+v1 endpoints auto-stop after `inactive_timeout` minutes of inactivity (default 60). `0` or `null`
+disables. v2 has no automatic idle shutdown; scale to zero (`0/0`) to stop billing.
 
-```shell
-# All models
-curl "https://api.together.xyz/v1/models" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json"
+### v1 → v2 command mapping
 
-# Dedicated-eligible models only
-curl "https://api.together.xyz/v1/models?dedicated=true" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json"
-```
+| v1 | v2 |
+| --- | --- |
+| `tg endpoints hardware --model <m>` | `tg beta models configs <model_id>` |
+| `tg endpoints create --model <m> --hardware <h>` | `tg beta endpoints deploy <model_id> --endpoint <name> [--config <cr_...>]` |
+| `tg endpoints update --min-replicas / --max-replicas <id>` | `tg beta endpoints update <dep_id> --min-replicas <n> --max-replicas <n>` |
+| `tg endpoints stop <id>` | `tg beta endpoints update <dep_id> --min-replicas 0 --max-replicas 0` |
+| `tg endpoints start <id>` | `tg beta endpoints update <dep_id> --min-replicas 1 --max-replicas <n>` |
+| `tg endpoints list` / `retrieve <id>` | `tg beta endpoints ls` / `tg beta endpoints get <ep_...>` |
+| `tg endpoints delete <id>` | Scale to `0/0`, then `tg beta endpoints rm <dep_...>` and `tg beta endpoints rm <ep_...>` |
 
-```shell
-together models list
-together models list --type dedicated
-together models list --json
-```
-
-## Using the Endpoint
-
-Once STARTED, use the Chat Completions API with either the endpoint **name** or **ID**. For
-management calls, use the endpoint ID. For inference, prefer the endpoint name once the deployment
-is stable:
-
-```python
-response = client.chat.completions.create(
-    model="endpoint-abc123",  # or endpoint name
-    messages=[{"role": "user", "content": "Hello!"}],
-)
-```
-
-```typescript
-const response = await together.chat.completions.create({
-  model: "endpoint-abc123",  // or endpoint name
-  messages: [{ role: "user", content: "Hello!" }],
-});
-console.log(response.choices[0].message.content);
-```
-
-```shell
-curl -X POST "https://api.together.xyz/v1/chat/completions" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "endpoint-abc123",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-
-## Auto-Shutdown
-
-Endpoints auto-stop after 1 hour of inactivity by default. Set `inactive_timeout` in minutes to
-change the behavior. Use `0` or `null` to disable auto-shutdown entirely.
-
-## Speculative Decoding
-
-Speculative decoding is controlled by `disable_speculative_decoding`. Leave it enabled for general
-throughput-oriented workloads. Disable it when tail latency matters more than average throughput.
-
-## Prompt Caching
-
-Prompt caching is enabled for dedicated endpoints and reduces latency on repeated prompt prefixes.
-Treat it as a default performance optimization rather than an optional advanced feature.
-
-## Availability Zones
-
-```shell
-together endpoints availability-zones
-together endpoints create --availability-zone us-central-4b ...
-```
-
-Only constrain availability zones when the workload has real geography or latency requirements.
-Restricting zones narrows available capacity and can make hardware placement harder.
-
-## Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| Hardware unavailable | Try a different compatible model or retry when capacity changes |
-| Hardware not eligible (404: "not available for this model") | The model only supports specific hardware configs. Run `list_hardware(model=...)` to see eligible options. Fine-tuned models often require larger hardware than their parameter count suggests |
-| Endpoint queued (not starting) | Reduce `min_replicas` to match currently available capacity |
-| Low replica scaling | Reduce `max_replicas` or wait for more hardware to become available |
-| Model not supported | Use a dedicated-eligible model from `together models list --type dedicated` |
-| Fine-tuned model won't deploy | Confirm the base model is supported on dedicated endpoints |
-
-## CLI Reference
-
-### Endpoint Commands
-
-| Command | Description |
-|---------|-------------|
-| `together endpoints create` | Create a new endpoint |
-| `together endpoints retrieve <ID>` | Get endpoint details |
-| `together endpoints list` | List endpoints |
-| `together endpoints update <ID>` | Update endpoint config |
-| `together endpoints start <ID>` | Start a stopped endpoint |
-| `together endpoints stop <ID>` | Stop a running endpoint |
-| `together endpoints delete <ID>` | Delete an endpoint |
-| `together endpoints hardware` | List available hardware |
-| `together endpoints availability-zones` | List availability zones |
-
-### Model Commands
-
-| Command | Description |
-|---------|-------------|
-| `together models upload` | Upload a custom model |
-| `together models list` | List available models |
-
-### Create Options
-
-| Flag | Description |
-|------|-------------|
-| `--model` | (required) Model to deploy |
-| `--hardware` | (required) Hardware config ID |
-| `--min-replicas` | Minimum replica count |
-| `--max-replicas` | Maximum replica count |
-| `--display-name` | Human-readable name |
-| `--no-auto-start` | Create in STOPPED state |
-| `--no-speculative-decoding` | Disable speculative decoding |
-| `--availability-zone` | Preferred availability zone |
-| `--wait` | Wait for endpoint to be ready |
-| `--json` | Output in JSON format |
-
-### List Options
-
-| Flag | Description |
-|------|-------------|
-| `--mine` | Show only your endpoints |
-| `--type` | Filter by `dedicated` or `serverless` |
-| `--usage-type` | Filter by `on-demand` or `reserved` |
-| `--json` | Output in JSON format |
-
-### Hardware Options
-
-| Flag | Description |
-|------|-------------|
-| `--model` | Filter by model compatibility |
-| `--available` | Show only available hardware (requires `--model`) |
-| `--json` | Output in JSON format |
-
-### Upload Options
-
-| Flag | Description |
-|------|-------------|
-| `--model-name` | (required) Name for the uploaded model |
-| `--model-source` | (required) HF repo URL or S3 presigned URL |
-| `--model-type` | `model` or `adapter` |
-| `--hf-token` | Hugging Face API token |
-| `--description` | Model description |
-| `--base-model` | Base model for adapters (serverless) |
-| `--lora-model` | LoRA pool for adapters (dedicated) |
-| `--json` | Output in JSON format |
-
-## Endpoint Response Object
-
-```json
-{
-  "object": "endpoint",
-  "id": "endpoint-d23901de-ef8f-44bf-b3e7-de9c1ca8f2d7",
-  "name": "devuser/Qwen/Qwen3.5-9B-FP8-a32b82a1",
-  "display_name": "My Endpoint",
-  "model": "Qwen/Qwen3.5-9B-FP8",
-  "hardware": "1x_nvidia_h100_80gb_sxm",
-  "type": "dedicated",
-  "owner": "devuser",
-  "state": "STARTED",
-  "autoscaling": { "min_replicas": 1, "max_replicas": 3 },
-  "created_at": "2025-02-04T10:43:55.405Z"
-}
-```
+See [migrate-from-v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1) for a
+full walkthrough.

--- a/skills/together-dedicated-endpoints/references/dedicated-models.md
+++ b/skills/together-dedicated-endpoints/references/dedicated-models.md
@@ -1,150 +1,125 @@
-# Dedicated Endpoints Model Reference
+# Dedicated model catalog
+
+Together publishes a rolling catalog of models supported for dedicated model inference (DMI). The
+canonical list is the [supported-models
+page](https://docs.together.ai/docs/dedicated-endpoints/models), which shows each architecture,
+its `displayType`, and the instance type of its smallest published [deployment
+profile](models-and-configs.md).
+
+The list below is a snapshot for quick reference. Always confirm with `tg beta models public
+--product DEDICATED` (v2) or `together models list --type dedicated` (v1) before you commit — the
+catalog changes as new architectures land and old ones age out.
+
 ## Contents
 
-- [Chat Models](#chat-models)
-- [Image Models](#image-models)
-- [Transcription Models](#transcription-models)
-- [Moderation Models](#moderation-models)
-- [Rerank Models](#rerank-models)
-- [Custom and Fine-tuned Models](#custom-and-fine-tuned-models)
+- [How to list models](#how-to-list-models)
+- [Chat and language models](#chat-and-language-models)
+- [Image models](#image-models)
+- [Transcription models](#transcription-models)
+- [Moderation models](#moderation-models)
+- [Rerank models](#rerank-models)
+- [Fine-tuned and uploaded models](#fine-tuned-and-uploaded-models)
 
+## How to list models
 
-Models available for deployment on dedicated endpoints. This list changes frequently -- use
-`together models list --type dedicated` for the current catalog.
+### v2 (default)
 
-## Chat Models
+```bash
+# All models available for dedicated inference (JSON records with deployment profiles)
+tg beta models public --product DEDICATED --json
 
-| Model | API ID | Context |
-|-------|--------|---------|
-| DeepSeek R1-0528 | deepseek-ai/DeepSeek-R1 | 163,840 |
-| DeepSeek R1 Distill Llama 70B | deepseek-ai/DeepSeek-R1-Distill-Llama-70B | 131,072 |
-| DeepSeek R1 Distill Qwen 14B | deepseek-ai/DeepSeek-R1-Distill-Qwen-14B | 131,072 |
-| DeepSeek V3-0324 | deepseek-ai/DeepSeek-V3 | 131,072 |
-| DeepSeek V3.1 | deepseek-ai/DeepSeek-V3.1 | 131,072 |
-| LLaMA-2 70B | meta-llama/Llama-2-70b-hf | 4,096 |
-| Llama 3.1 405B Instruct | meta-llama/Llama-3.1-405B-Instruct | 4,096 |
-| Llama 3.2 1B Instruct | meta-llama/Llama-3.2-1B-Instruct | 131,072 |
-| Llama 3.3 70B Instruct Turbo | meta-llama/Llama-3.3-70B-Instruct-Turbo | 131,072 |
-| Llama 4 Maverick 17Bx128E | meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 | 1,048,576 |
-| Llama 4 Scout 17Bx16E | meta-llama/Llama-4-Scout-17B-16E-Instruct | 1,048,576 |
-| Meta Llama 3 70B Instruct Turbo | meta-llama/Meta-Llama-3-70B-Instruct-Turbo | 8,192 |
-| Meta Llama 3 8B Instruct | meta-llama/Meta-Llama-3-8B-Instruct | 8,192 |
-| Mistral 7B Instruct v0.1 | mistralai/Mistral-7B-Instruct-v0.1 | 32,768 |
-| Mistral 7B Instruct v0.2 | mistralai/Mistral-7B-Instruct-v0.2 | 32,768 |
-| Mistral 7B Instruct v0.3 | mistralai/Mistral-7B-Instruct-v0.3 | 32,768 |
-| Mixtral-8x7B Instruct v0.1 | mistralai/Mixtral-8x7B-Instruct-v0.1 | 32,768 |
-| OpenAI GPT-OSS 120B | openai/gpt-oss-120b | 131,072 |
-| OpenAI GPT-OSS 20B | openai/gpt-oss-20b | 131,072 |
-| Qwen2.5 72B Instruct | Qwen/Qwen2.5-72B-Instruct | 32,768 |
-| Qwen2.5 72B Instruct Turbo | Qwen/Qwen2.5-72B-Instruct-Turbo | 131,072 |
-| Qwen2.5 7B Instruct Turbo | Qwen/Qwen2.5-7B-Instruct-Turbo | 32,768 |
-| Qwen2.5 Coder 32B Instruct | Qwen/Qwen2.5-Coder-32B-Instruct | 16,384 |
-| Qwen2.5-VL 72B Instruct | Qwen/Qwen2.5-VL-72B-Instruct | 32,768 |
-| Qwen3 235B A22B FP8 | Qwen/Qwen3-235B-A22B-fp8-tput | 40,960 |
-| Qwen3 Coder 480B A35B FP8 | Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 | 262,144 |
-| Qwen3 Next 80B A3B | Qwen/Qwen3-Next-80B-A3B-Instruct | 262,144 |
-| QwQ-32B | Qwen/QwQ-32B | 131,072 |
-| GLM-4.5 Air FP8 | zai-org/GLM-4.5-Air-FP8 | 131,072 |
+# Filter
+tg beta models public --modality TEXT --search qwen
+tg beta models public --modality VIDEO
 
-## Image Models
+# Configs published for a specific weight
+tg beta models configs ml_CbJNwQC2ZqCU2iFT3mrCh
+```
 
-| Model | API ID |
-|-------|--------|
-| FLUX.1 Kontext [max] | black-forest-labs/FLUX.1-kontext-max |
-| FLUX.1 Kontext [pro] | black-forest-labs/FLUX.1-kontext-pro |
+Each record includes `id` (`arch_...`), `name` (Hugging Face model ID), `displayName`,
+`displayType`, and `deploymentProfiles[]` with the certified model + config pair. See
+[models-and-configs.md](models-and-configs.md#list-supported-models) for the response shape.
 
-## Transcription Models
+### v1 (legacy)
 
-| Model | API ID |
-|-------|--------|
-| Whisper large-v3 | openai/whisper-large-v3 |
-
-## Moderation Models
-
-| Model | API ID | Context |
-|-------|--------|---------|
-| Llama Guard 4 12B | meta-llama/Llama-Guard-4-12B | 1,048,576 |
-
-## Rerank Models
-
-| Model | API ID | Context |
-|-------|--------|---------|
-| Llama Rank V1 | Salesforce/Llama-Rank-V1 | 8,192 |
-
-## Custom and Fine-tuned Models
-
-Custom uploaded models and fine-tuned models can also be deployed on dedicated endpoints.
-
-### Requirements
-
-- **Format**: Hugging Face-compatible (`config.json`, tokenizer files, safetensors)
-- **Types**: Text generation and embedding models
-- **Scale**: Must fit on a single node (multi-node not supported)
-- **Fine-tuned**: Base model must be a supported dedicated endpoint model
-- **Sources**: Hugging Face Hub or S3 (`.zip`, `.tar`, `.tar.gz`)
-
-### Upload Custom Model
+```bash
+together models list --type dedicated
+together models list --json
+```
 
 ```python
-from together import Together
-client = Together()
-
-# From Hugging Face
-response = client.models.upload(
-    model_name="my-custom-model",
-    model_source="https://huggingface.co/your-org/your-model",
-    hf_token="hf_...",
-)
-print(response.data.job_id)
-
-# From S3 (presigned URL, at least 100 min validity)
-response = client.models.upload(
-    model_name="my-s3-model",
-    model_source="https://my-bucket.s3.amazonaws.com/model.tar.gz?...",
-)
+models = client.models.list()  # filter for dedicated eligibility in client-side
 ```
 
-```shell
-# From Hugging Face
-together models upload \
-  --model-name my-custom-model \
-  --model-source https://huggingface.co/your-org/your-model \
-  --hf-token $HF_TOKEN
+## Chat and language models
 
-# From S3
-together models upload \
-  --model-name my-s3-model \
-  --model-source "$PRESIGNED_URL"
-```
+| Model | API ID | Context |
+| --- | --- | --- |
+| DeepSeek R1-0528 | `deepseek-ai/DeepSeek-R1` | 163,840 |
+| DeepSeek R1 Distill Llama 70B | `deepseek-ai/DeepSeek-R1-Distill-Llama-70B` | 131,072 |
+| DeepSeek R1 Distill Qwen 14B | `deepseek-ai/DeepSeek-R1-Distill-Qwen-14B` | 131,072 |
+| DeepSeek V3-0324 | `deepseek-ai/DeepSeek-V3` | 131,072 |
+| DeepSeek V3.1 | `deepseek-ai/DeepSeek-V3.1` | 131,072 |
+| LLaMA-2 70B | `meta-llama/Llama-2-70b-hf` | 4,096 |
+| Llama 3.1 405B Instruct | `meta-llama/Llama-3.1-405B-Instruct` | 4,096 |
+| Llama 3.2 1B Instruct | `meta-llama/Llama-3.2-1B-Instruct` | 131,072 |
+| Llama 3.3 70B Instruct Turbo | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | 131,072 |
+| Llama 4 Maverick 17Bx128E | `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | 1,048,576 |
+| Llama 4 Scout 17Bx16E | `meta-llama/Llama-4-Scout-17B-16E-Instruct` | 1,048,576 |
+| Meta Llama 3 70B Instruct Turbo | `meta-llama/Meta-Llama-3-70B-Instruct-Turbo` | 8,192 |
+| Meta Llama 3 8B Instruct | `meta-llama/Meta-Llama-3-8B-Instruct` | 8,192 |
+| Mistral 7B Instruct v0.1 | `mistralai/Mistral-7B-Instruct-v0.1` | 32,768 |
+| Mistral 7B Instruct v0.2 | `mistralai/Mistral-7B-Instruct-v0.2` | 32,768 |
+| Mistral 7B Instruct v0.3 | `mistralai/Mistral-7B-Instruct-v0.3` | 32,768 |
+| Mixtral-8x7B Instruct v0.1 | `mistralai/Mixtral-8x7B-Instruct-v0.1` | 32,768 |
+| OpenAI GPT-OSS 120B | `openai/gpt-oss-120b` | 131,072 |
+| OpenAI GPT-OSS 20B | `openai/gpt-oss-20b` | 131,072 |
+| Qwen2.5 72B Instruct | `Qwen/Qwen2.5-72B-Instruct` | 32,768 |
+| Qwen2.5 72B Instruct Turbo | `Qwen/Qwen2.5-72B-Instruct-Turbo` | 131,072 |
+| Qwen2.5 7B Instruct Turbo | `Qwen/Qwen2.5-7B-Instruct-Turbo` | 32,768 |
+| Qwen2.5 Coder 32B Instruct | `Qwen/Qwen2.5-Coder-32B-Instruct` | 16,384 |
+| Qwen2.5-VL 72B Instruct | `Qwen/Qwen2.5-VL-72B-Instruct` | 32,768 |
+| Qwen3 235B A22B FP8 | `Qwen/Qwen3-235B-A22B-fp8-tput` | 40,960 |
+| Qwen3 Coder 480B A35B FP8 | `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` | 262,144 |
+| Qwen3 Next 80B A3B | `Qwen/Qwen3-Next-80B-A3B-Instruct` | 262,144 |
+| QwQ-32B | `Qwen/QwQ-32B` | 131,072 |
+| GLM-4.5 Air FP8 | `zai-org/GLM-4.5-Air-FP8` | 131,072 |
 
-### Deploy Custom or Fine-tuned Model
+## Image models
 
-```shell
-# Verify model appears
-together models list
+| Model | API ID |
+| --- | --- |
+| FLUX.1 Kontext [max] | `black-forest-labs/FLUX.1-kontext-max` |
+| FLUX.1 Kontext [pro] | `black-forest-labs/FLUX.1-kontext-pro` |
 
-# Check hardware options
-together endpoints hardware --model <model-name>
+## Transcription models
 
-# Deploy
-together endpoints create \
-  --model <model-name> \
-  --hardware 2x_nvidia_h100_80gb_sxm \
-  --display-name "Custom Model Endpoint" \
-  --no-speculative-decoding \
-  --wait
-```
+| Model | API ID |
+| --- | --- |
+| Whisper large-v3 | `openai/whisper-large-v3` |
 
-### Deploy Fine-tuned Model
+## Moderation models
 
-```shell
-# Find model output name from fine-tuning job
-together fine-tuning list
+| Model | API ID | Context |
+| --- | --- | --- |
+| Llama Guard 4 12B | `meta-llama/Llama-Guard-4-12B` | 1,048,576 |
 
-# Deploy
-together endpoints create \
-  --model <your-model-output-name> \
-  --hardware 4x_nvidia_h100_80gb_sxm \
-  --display-name "Fine-tuned Endpoint" \
-  --wait
-```
+## Rerank models
+
+| Model | API ID | Context |
+| --- | --- | --- |
+| Llama Rank V1 | `Salesforce/Llama-Rank-V1` | 8,192 |
+
+## Fine-tuned and uploaded models
+
+Fine-tuned and uploaded models are also deployable on DMI, subject to two rules:
+
+- **Base architecture must be supported.** An upload can't introduce a new base architecture.
+- **File format must match `from_pretrained` layout** — `config.json`, tokenizer files, sharded
+  `model-*.safetensors`, and index files. Adapters require `adapter_config.json` and
+  `adapter_model.safetensors`.
+
+The v2 upload workflow is `tg beta models create` → `tg beta models upload` (or
+`remote-uploads create`) → poll job → `tg beta endpoints deploy`. See
+[models-and-configs.md](models-and-configs.md#upload-a-fine-tuned-model) for the walkthrough,
+including LoRA adapters and troubleshooting.

--- a/skills/together-dedicated-endpoints/references/hardware-options.md
+++ b/skills/together-dedicated-endpoints/references/hardware-options.md
@@ -1,42 +1,184 @@
-# Dedicated Endpoints Hardware Reference
+# Hardware and pricing
+
+Dedicated model inference bills by the minute per running replica, by hardware. Model, prompt
+volume, and request count don't affect the per-replica price — a larger model just needs bigger or
+more GPUs.
+
 ## Contents
 
-- [Hardware ID Format](#hardware-id-format)
-- [GPU Types](#gpu-types)
-- [Common Configurations](#common-configurations)
-- [Hardware Availability Status](#hardware-availability-status)
-- [Hardware Response Object](#hardware-response-object)
-- [Pricing Model](#pricing-model)
-- [GPU Selection Guide](#gpu-selection-guide)
-- [Scaling](#scaling)
-- [Autoscaling Schema](#autoscaling-schema)
+- [Instance type IDs (v2)](#instance-type-ids-v2)
+- [Hardware IDs (v1, legacy)](#hardware-ids-v1-legacy)
+- [Currently offered GPUs](#currently-offered-gpus)
+- [Per-hour pricing](#per-hour-pricing)
+- [On-demand vs reserved](#on-demand-vs-reserved)
+- [How scaling affects cost](#how-scaling-affects-cost)
+- [Instance-type headroom](#instance-type-headroom)
+- [GPU selection guide](#gpu-selection-guide)
+- [Query hardware programmatically](#query-hardware-programmatically)
+- [Deprecated hardware families](#deprecated-hardware-families)
 
+## Instance type IDs (v2)
 
-## Hardware ID Format
+DMI v2 refers to hardware by **instance type**, identified with a dashed lowercase ID like
+`1xnvidia-h100-80gb`. Each instance type has a per-hour price and per-region capacity. A config's
+`accelerator_type` + `accelerator_count` selectors map to an instance type; the deployment inherits
+it from the config you pick.
 
-`[count]x_nvidia_[gpu_type]_[memory]_[link]`
+Currently listed instance types:
 
-Example: `2x_nvidia_h100_80gb_sxm`
+| Instance type | GPU |
+| --- | --- |
+| `1xnvidia-h100-80gb` | 1x H100 80GB |
+| `1xnvidia-h200-141gb` | 1x H200 141GB |
+| `1xnvidia-b200-180gb` | 1x B200 180GB |
+| `1xnvidia-gb300-280gb` | 1x GB300 280GB |
+| `1xnvidia-b300-280gb` | 1x B300 280GB |
 
-## GPU Types
+Multi-GPU configs use the same GPU model in higher counts and cost proportionally more (see
+[Per-hour pricing](#per-hour-pricing)). List every instance type — including multi-GPU variants —
+with the public catalog:
 
-Currently offered hardware families:
+```bash
+curl -s -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  https://api.together.ai/v2/public/inference-instance-types
+```
 
-| GPU | Memory | Notes |
-|-----|--------|-------|
-| H100 SXM | 80GB | Production workhorse, broad model coverage |
-| H200 SXM | 140GB | Larger HBM than H100 for memory-bound workloads |
-| B200 SXM | 180GB | Highest performance, largest single-GPU memory |
+## Hardware IDs (v1, legacy)
 
-A100, L40, L40S, and RTX 6000 are no longer offered for new dedicated endpoints. The `/v1/hardware`
-endpoint may still return deprecated SKUs; treat only H100, H200, and B200 as deployable.
+v1 endpoints use the older underscore format, for example `1x_nvidia_h100_80gb_sxm`. These IDs are
+returned by `/v1/hardware` and accepted by `together endpoints create --hardware`. Format:
 
-Hardware availability varies by region and demand. Use the API or CLI to get current options:
+```
+[count]x_nvidia_[gpu_type]_[memory]_[link]
+```
+
+Example v1 hardware IDs:
+
+| Hardware ID (v1) | GPU | Typical use |
+| --- | --- | --- |
+| `1x_nvidia_h100_80gb_sxm` | 1x H100 | Small models (up to ~9B) |
+| `2x_nvidia_h100_80gb_sxm` | 2x H100 | Medium models (7–20B) |
+| `4x_nvidia_h100_80gb_sxm` | 4x H100 | Large models (70B) |
+| `8x_nvidia_h100_80gb_sxm` | 8x H100 | Very large models (120B+, MoE) |
+| `1x_nvidia_h200_140gb_sxm` | 1x H200 | Memory-bound small/medium |
+| `4x_nvidia_h200_140gb_sxm` | 4x H200 | Large + bigger KV cache |
+| `8x_nvidia_h200_140gb_sxm` | 8x H200 | Very large / long-context |
+| `1x_nvidia_b200_180gb_sxm` | 1x B200 | Highest single-GPU perf |
+| `8x_nvidia_b200_180gb_sxm` | 8x B200 | Max throughput / largest models |
+
+v1 hardware IDs and v2 instance type IDs address the same underlying hardware but are not
+interchangeable across the two APIs.
+
+## Currently offered GPUs
+
+| GPU family | Memory | Notes |
+| --- | --- | --- |
+| H100 SXM | 80 GB | Production workhorse; broadest model coverage. |
+| H200 SXM | 141 GB | Larger HBM for memory-bound / long-context workloads. |
+| B200 SXM | 180 GB | Highest per-GPU performance; largest single-GPU memory. |
+| B300 SXM | 280 GB | Next-generation. Contact sales. |
+| GB300 | 280 GB | Grace-Blackwell superchip. Contact sales. |
+
+## Per-hour pricing
+
+Public rates from the DMI [pricing page](https://docs.together.ai/docs/dedicated-endpoints/pricing).
+Multi-GPU configs of the same family cost proportionally more (a 4-GPU config costs 4x the
+single-GPU rate).
+
+| GPU | Instance type (v2) | Cost/hour |
+| --- | --- | --- |
+| H100 80GB | `1xnvidia-h100-80gb` | $5.49 |
+| H200 141GB | `1xnvidia-h200-141gb` | Contact sales |
+| B200 180GB | `1xnvidia-b200-180gb` | $8.99 |
+| GB300 280GB | `1xnvidia-gb300-280gb` | Contact sales |
+| B300 280GB | `1xnvidia-b300-280gb` | Contact sales |
+
+Each running replica bills independently. A deployment running three replicas bills three times
+the single-replica rate. Replicas stop billing as soon as they scale down; a deployment at zero
+replicas (or stopped) costs nothing.
+
+Prices update over time — for the authoritative live rates always call the
+`/v2/public/inference-instance-types` endpoint or the pricing page.
+
+## On-demand vs reserved
+
+- **On-demand** — Per-minute rate for as long as replicas run, no commitment. Capacity scales
+  within replica bounds. Best for variable traffic and prototyping.
+- **Reserved** — Committed capacity for a set term at a lower effective rate, with guaranteed
+  hardware availability. Best for steady production traffic.
+  [Contact sales](https://www.together.ai/forms/monthly-reserved) to arrange.
+
+## How scaling affects cost
+
+Billing is proportional to running replicas across all deployments in your project.
+
+- `minReplicas` sets the **floor** on cost. These replicas always run and always bill.
+- `maxReplicas` sets the **ceiling** on cost. The deployment never bills for more than this many
+  replicas at once.
+- Stopped or `0/0` deployments bill nothing. Restarting one costs a
+  [cold start](https://docs.together.ai/docs/dedicated-endpoints/concepts#cold-starts) on the first
+  request afterward.
+
+**There is no automatic idle shutdown at launch on v2.** v1 endpoints auto-stop after
+`inactive_timeout` minutes (default 60); on v2 you must scale to `0/0` to stop billing when the
+workload is idle.
+
+### DMI vs serverless break-even (rule of thumb)
+
+- A single H100 replica at $5.49/hr is ~$132/day, or ~$3,950 across a 30-day month if it runs
+  continuously.
+- Serverless is usually cheaper for low or bursty traffic; DMI is usually cheaper when a replica
+  would stay busy most of the day.
+- Stopping DMI when idle narrows the gap for spiky traffic. It doesn't help for steady low-volume
+  traffic around the clock — serverless wins there.
+
+## Instance-type headroom
+
+Region availability is reported as `headroom`. For each region, `/v2/public/inference-instance-types`
+returns how many more replicas currently fit. A headroom value of `N` with the `RELATION_GTE`
+relation means at least N units are free; actual availability may be higher. Use it to pick a
+region with capacity before you deploy.
+
+## GPU selection guide
+
+| Need | Recommendation |
+| --- | --- |
+| Small models (≤ 9B) | 1x H100 |
+| Medium models (7–20B) | 1–2x H100 |
+| Large models (70B) | 4–8x H100 or 4x H200 |
+| Very large / MoE models (120B+) | 8x H100, 8x H200, or 8x B200 |
+| Maximum throughput | 8x B200 + multiple replicas |
+| Cost-effective baseline | H100 (lowest per-hour listed rate) |
+| Long-context / memory-bound | H200 or B200 (larger HBM) |
+| Maximum single-GPU performance | B200 (or B300 / GB300 for the newest generation) |
+
+Fine-tuned and uploaded models may require larger hardware than their base parameter count
+suggests. On v2, always list the profiles published for the specific weight and pick a config from
+the list:
+
+```bash
+tg beta models configs ml_your_model_id
+```
+
+## Query hardware programmatically
+
+### v2
+
+```bash
+# All instance types with per-region headroom
+curl -s -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  https://api.together.ai/v2/public/inference-instance-types
+
+# All configs published for a specific weight
+tg beta models configs ml_CbJNwQC2ZqCU2iFT3mrCh
+
+# Every deployment profile in the public catalog (per-architecture)
+tg beta models public --product DEDICATED --json
+```
+
+### v1 (legacy)
 
 ```python
-from together import Together
-client = Together()
-
 response = client.endpoints.list_hardware(model="Qwen/Qwen3.5-9B-FP8")
 for hw in response.data:
     status = hw.availability.status if hw.availability else "unknown"
@@ -44,33 +186,11 @@ for hw in response.data:
     print(f"  {hw.id}  ({status}, {price}c/min)")
 ```
 
-```shell
+```bash
 together endpoints hardware --model Qwen/Qwen3.5-9B-FP8 --available
 ```
 
-## Common Configurations
-
-| Hardware ID | GPU | Count | Typical Use |
-|------------|-----|-------|-------------|
-| `1x_nvidia_h100_80gb_sxm` | H100 | 1 | Small models (up to ~9B) |
-| `2x_nvidia_h100_80gb_sxm` | H100 | 2 | Medium models (7-20B) |
-| `4x_nvidia_h100_80gb_sxm` | H100 | 4 | Large models (70B) |
-| `8x_nvidia_h100_80gb_sxm` | H100 | 8 | Very large models (120B+, MoE) |
-| `1x_nvidia_h200_140gb_sxm` | H200 | 1 | Memory-bound small/medium models |
-| `4x_nvidia_h200_140gb_sxm` | H200 | 4 | Large models with bigger KV cache |
-| `8x_nvidia_h200_140gb_sxm` | H200 | 8 | Very large or long-context models |
-| `1x_nvidia_b200_180gb_sxm` | B200 | 1 | Highest single-GPU performance |
-| `8x_nvidia_b200_180gb_sxm` | B200 | 8 | Maximum throughput / largest models |
-
-## Hardware Availability Status
-
-| Status | Meaning |
-|--------|---------|
-| `available` | Ready for deployment |
-| `unavailable` | Currently not available |
-| `insufficient` | Some capacity but may be limited |
-
-## Hardware Response Object
+v1 `Hardware` object:
 
 ```json
 {
@@ -88,78 +208,10 @@ together endpoints hardware --model Qwen/Qwen3.5-9B-FP8 --available
 }
 ```
 
-## Pricing Model
+Availability values: `available`, `unavailable`, `insufficient`.
 
-- **Billed per minute** while endpoint is running (even when idle)
-- **No charge** during spin-up or for failed deployments
-- **Stop endpoint** to pause charges
-- Price varies by hardware configuration (check `cents_per_minute`)
+## Deprecated hardware families
 
-### Single-GPU on-demand rates
-
-Reference prices for the currently-offered single-GPU SKUs (multiply by GPU count for multi-GPU
-configurations of the same family; for the authoritative live rates always call the API or CLI):
-
-| Hardware ID | Cost/hour |
-|-------------|-----------|
-| `1x_nvidia_h100_80gb_sxm` | $5.40 |
-| `1x_nvidia_h200_140gb_sxm` | $6.60 |
-| `1x_nvidia_b200_180gb_sxm` | $9.00 |
-
-Multi-GPU hardware IDs share the single-GPU suffix, e.g. four H100s use `4x_nvidia_h100_80gb_sxm`.
-Cost scales linearly with the GPU count.
-
-Each running replica bills independently and stops billing as soon as it is scaled down. Run
-`together endpoints hardware --model <MODEL_ID>` (or `tg endpoints hardware --model <MODEL_ID>`)
-for the per-model list with current per-minute rates.
-
-## GPU Selection Guide
-
-| Need | Recommendation |
-|------|---------------|
-| Small models (up to 9B) | 1x H100 |
-| Medium models (7-20B) | 1-2x H100 |
-| Large models (70B) | 4-8x H100 or 4x H200 |
-| Very large / MoE models (120B+) | 8x H100, 8x H200, or 8x B200 |
-| Maximum throughput | 8x B200 + multiple replicas |
-| Cost-effective baseline | H100 (lowest per-hour rate of currently-offered SKUs) |
-| Long-context / memory-bound | H200 or B200 (larger HBM) |
-| Maximum performance | B200 (newest generation, highest single-GPU speed) |
-
-Fine-tuned and custom-uploaded models may require larger hardware than their base parameter count
-suggests. For example, a fine-tuned 8B model may only be eligible for 4x or 8x H100 configs.
-Always call `list_hardware(model=...)` to get the authoritative list of eligible hardware before
-creating an endpoint:
-
-```python
-response = client.endpoints.list_hardware(model="your-username/your-finetuned-model")
-for hw in response.data:
-    status = hw.availability.status if hw.availability else "unknown"
-    print(f"  {hw.id}  ({status})")
-```
-
-## Scaling
-
-### Horizontal (Replicas)
-
-- Increases maximum QPS
-- Linear cost scaling
-- Best for high-concurrency workloads
-
-### Vertical (GPU Count)
-
-- Increases generation speed
-- Reduces time-to-first-token
-- Best for latency-sensitive workloads
-
-## Autoscaling Schema
-
-```json
-{
-  "min_replicas": 1,
-  "max_replicas": 5
-}
-```
-
-- `min_replicas`: Always running (even with no traffic)
-- `max_replicas`: Maximum under load
+A100, L40, L40S, and RTX 6000 are no longer offered for new dedicated endpoints. The v1
+`/v1/hardware` endpoint may still return deprecated SKUs; treat only H100, H200, and B200 (plus
+the contact-sales-only B300 and GB300) as deployable.

--- a/skills/together-dedicated-endpoints/references/models-and-configs.md
+++ b/skills/together-dedicated-endpoints/references/models-and-configs.md
@@ -1,0 +1,310 @@
+# Models, configs, and deployment profiles (v2)
+
+DMI v2 splits what v1 called "a model" into three layered concepts:
+
+- **Architecture** — the top-level catalog entry (e.g. `zai-org/GLM-5.2`), identified by an
+  `arch_...` slug. This is the family you pick from the [supported-models
+  catalog](https://docs.together.ai/docs/dedicated-endpoints/models).
+- **Weight (model)** — a concrete build of an architecture at one quantization (e.g. BF16 or FP8),
+  identified by `ml_...`. Weights are what you actually deploy. An architecture can have several.
+- **Config (`cr_...`)** — a certified serving spec for one weight, fixing engine, parallelism,
+  hardware, and optimization. Immutable. New revisions get new IDs.
+
+A **deployment profile** is a certified pair of one weight + one config, published in the catalog.
+When an architecture has one profile the CLI selects it automatically; when it has several, pass
+`--config <cr_...>`.
+
+## Contents
+
+- [List supported models](#list-supported-models)
+- [List a model's profiles](#list-a-models-profiles)
+- [Upload a fine-tuned model](#upload-a-fine-tuned-model)
+- [Upload a LoRA adapter](#upload-a-lora-adapter)
+- [Choose a profile](#choose-a-profile)
+- [Decoding optimizations](#decoding-optimizations)
+
+## List supported models
+
+Use the [supported-models catalog](https://docs.together.ai/docs/dedicated-endpoints/models) as the
+primary source of truth — it lists deployable architectures with their smallest published profile's
+`Deployable hardware` (instance type). For the same data in JSON:
+
+```bash
+# All models available for dedicated inference
+tg beta models public --product DEDICATED
+
+# Narrow by modality or search
+tg beta models public --modality TEXT --search qwen
+
+# Full JSON records, including deploymentProfiles[]
+tg beta models public --product DEDICATED --json
+```
+
+Response shape:
+
+```json
+{
+  "data": [
+    {
+      "id": "arch_abc123",
+      "name": "zai-org/GLM-5.2",
+      "displayName": "GLM 5.2",
+      "displayType": "chat",
+      "deploymentProfiles": [
+        {
+          "profileId": "cfg_a",
+          "certifiedConfigRevisionId": "cr_certified",
+          "certifiedModelRevisionId": "rv_snap",
+          "config": "projects/proj_cfg/configs/cr_certified",
+          "model": "projects/proj_weights/models/ml_weight/revisions/rv_snap",
+          "parallelism": "TP8",
+          "gpuType": "H100",
+          "gpuCount": 8
+        }
+      ]
+    }
+  ]
+}
+```
+
+Identity fields per architecture:
+
+| Field | Description |
+| --- | --- |
+| `id` | Architecture UID (`arch_...`). |
+| `name` | Catalog-controlled Hugging Face model ID (e.g. `zai-org/GLM-5.2`). |
+| `displayName` | Human-readable name (e.g. `GLM 5.2`). |
+| `displayType` | One of `chat`, `language`, `code`, `image`, `embedding`, `rerank`, `moderation`, `audio`, `video`, `transcribe`. |
+
+Deployment-profile fields:
+
+| Field | Description |
+| --- | --- |
+| `config` | Resource name `projects/{project_id}/configs/{config_revision_id}`. Empty when unpinned. |
+| `model` | Resource name `projects/{project_id}/models/{model_id}[/revisions/{revision_id}]`. Empty when unpinned. |
+| `parallelism` | Free-form parallelism spec (e.g. `TP8`, `TP4`, `EP`, `PD`). |
+| `gpuType`, `gpuCount` | Hardware summary. |
+
+Copy `model` and `config` straight into the corresponding fields of a create-deployment request.
+
+## List a model's profiles
+
+For a specific weight (public or your own uploaded model):
+
+```bash
+tg beta models configs ml_CbJNwQC2ZqCU2iFT3mrCh
+```
+
+```json
+{
+  "data": [
+    {
+      "id": "cr_CbeuemXsU8yGStQvBBEgY",
+      "referenceModel": "projects/proj_weights/models/ml_CbJ9yCnij7A47b1xkpioB",
+      "referenceModelId": "ml_CbJ9yCnij7A47b1xkpioB",
+      "projectId": "proj_abc123",
+      "selectors": [
+        {"key": "accelerator_count", "value": "1"},
+        {"key": "accelerator_type",  "value": "nvidia-h100-80gb"},
+        {"key": "optimization",      "value": "balanced"},
+        {"key": "topology",          "value": "aggregated"}
+      ]
+    }
+  ]
+}
+```
+
+The config `id` is a config revision. Pass it as a resource name in the `config` field of a
+create-deployment request, using the config's `projectId` for `{project_id}` (often a Together
+platform project rather than yours):
+
+```
+projects/{project_id}/configs/{config_revision_id}
+```
+
+Config selectors:
+
+| Selector | Description | Example |
+| --- | --- | --- |
+| `accelerator_type` | GPU SKU. | `nvidia-h100-80gb` |
+| `accelerator_count` | GPUs per replica. | `1`, `2`, `4`, `8` |
+| `optimization` | Serving profile. | `balanced`, `throughput`, `latency` |
+| `topology` | Layout across GPUs. | `aggregated` |
+
+## Upload a fine-tuned model
+
+Uploads must be **fine-tuned variants of a supported base architecture**. Not every model is
+accepted; unsupported architectures, layer types, or adapter ranks are rejected at create or upload.
+
+File format is standard Hugging Face `from_pretrained`-compatible layout (`config.json`,
+`tokenizer_config.json`, `tokenizer.json`, sharded `model-*.safetensors`, `model.safetensors.index.json`,
+etc.).
+
+### S3 archive requirements
+
+- Package files in a `.zip` or `.tar.gz`.
+- Files must be at the **root** of the archive — no extra top-level directory.
+- Presigned URL expiration ≥ 100 minutes.
+
+To create the archive from within a model directory:
+
+```bash
+cd /path/to/your/model
+tar -czvf ../model.tar.gz .
+```
+
+### Step 1: Create the model record
+
+```bash
+tg beta models create gemma-4-31b-it \
+  --base-model ml_CbJNwQC2ZqCU2iFT3mrCh
+```
+
+Save the returned `id` (for example `ml_abc123`). `--base-model` takes the base weight's
+`baseModelId` (`ml_...`), NOT the architecture `arch_...`.
+
+Uploaded models are **Private** by default (visible only to project members). Internal makes them
+visible to the whole organization; Public makes them visible to anyone.
+
+Create fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | Yes | Inference-addressable name. Prefer a readable name over a Hugging Face repo ID. |
+| `base_model_id` | Yes | `baseModelId` (`ml_...`) of the supported base. |
+| `description` | No | Description shown in the project catalog. |
+| `type` | No | `model` (default) or `adapter`. Fixed at create. |
+
+### Step 2: Upload the weights
+
+```bash
+# From your machine (multipart handled by the CLI)
+tg beta models upload ml_abc123 ./path/to/model-dir
+
+# From Hugging Face Hub or S3 (server-side stream)
+tg beta models remote-uploads create ml_abc123 \
+  --from https://huggingface.co/your-org/your-repo \
+  --token hf_your_token
+```
+
+Remote-upload job response (relevant fields at top level):
+
+```json
+{
+  "id": "job_abc123",
+  "projectId": "proj_abc123",
+  "modelId": "ml_abc123",
+  "remoteUrl": "https://huggingface.co/your-org/your-repo",
+  "status": "REMOTE_UPLOAD_STATUS_PENDING",
+  "statusMessage": "",
+  "restartCount": 0,
+  "maxRestarts": 0,
+  "createdAt": "2026-07-02T20:00:00Z",
+  "updatedAt": "2026-07-02T20:00:00Z"
+}
+```
+
+Poll until `REMOTE_UPLOAD_STATUS_SUCCEEDED`:
+
+```bash
+tg beta models remote-uploads retrieve job_abc123
+tg beta models remote-uploads list
+tg beta models ls-files ml_abc123           # confirm files landed
+```
+
+### Step 3: Deploy
+
+```bash
+tg beta endpoints deploy ml_abc123 \
+  --endpoint my-custom-model \
+  --config cr_CbzGdmn14t3HYrXXitmKa
+```
+
+### Common troubleshooting
+
+- **"Model not found" during upload** — Create the record first with `tg beta models create`, then
+  pass the returned `id` to the upload.
+- **`base_model_id is required` on create** — Use the `baseModelId` (`ml_...`), not the
+  architecture `arch_...`.
+- **`tokenizer.chat_template is not set` during chat inference** — Uploaded tokenizer has no chat
+  template. Add a compatible `chat_template` to `tokenizer_config.json` before upload, or use the
+  text-completions API.
+- **Model delete fails with `the model is referenced by a live deployment`** — Stop the deployment,
+  wait for `DEPLOYMENT_STATE_STOPPED`, delete the deployment, then delete the model.
+
+## Upload a LoRA adapter
+
+Same workflow as full models, with `--type adapter` on create. Adapters must target a base model
+that Together AI supports for dedicated inference.
+
+Requirements:
+
+- **Source** — Hugging Face Hub or S3 presigned URL.
+- **Files** — `adapter_config.json` and `adapter_model.safetensors` at the root of the archive
+  (S3) or the Hugging Face repo.
+- **Base model** — Supported for dedicated inference.
+
+Naming tip: strip any org prefix from the repo name (use `glue_stsb`, not `predibase/glue_stsb`).
+The server prepends your project slug on top; adapters that already have a doubled slug can't be
+renamed — the only fix is to delete and re-upload under the correct name.
+
+```bash
+tg beta models create my-stsb-lora \
+  --type adapter \
+  --base-model ml_CbJNwQC2ZqCU2iFT3mrCh
+
+tg beta models remote-uploads create ml_abc123 \
+  --from https://huggingface.co/your-org/your-adapter \
+  --token hf_your_token
+
+tg beta endpoints deploy ml_abc123 \
+  --endpoint my-adapter \
+  --config cr_CbzGdmn14t3HYrXXitmKa
+```
+
+Deploying an adapter creates its own endpoint. To hot-load multiple LoRA adapters at runtime on
+one shared endpoint, deploy the base model with `--enable-lora` and follow the multi-LoRA v1
+adapter flow (`docs/dedicated-endpoints/v1/lora-adapter`); at the v2 initial launch, multi-LoRA
+serving is a v1-only feature.
+
+### Common troubleshooting
+
+- **"Model name already exists"** — Adapter names must be unique. Versioning isn't supported;
+  re-upload under a new name.
+- **Missing required files** — Confirm both `adapter_config.json` and `adapter_model.safetensors`
+  exist at the root.
+- **Base model incompatibility** — Verify the base is in the [supported-models
+  catalog](https://docs.together.ai/docs/dedicated-endpoints/models).
+- **Upload job stuck in `Processing`** — Source unreachable. Check S3 presigned URL expiration or
+  Hugging Face token permissions.
+- **`401` / `403` during upload** — Check `TOGETHER_API_KEY`, Hugging Face token scope for private
+  repos, and S3 URL validity.
+- **Adapter delete fails with `the model is referenced by a live deployment`** — Stop the
+  deployment, wait for `STOPPED`, delete the deployment, then delete the adapter.
+
+## Choose a profile
+
+Match the profile to the workload:
+
+- **Single-GPU, `balanced`** — Default for most models; lowest per-replica cost.
+- **Multi-GPU** — Higher throughput and lower latency for large models; scales cost per replica.
+- **`latency`** — Time-to-first-token matters more than aggregate throughput.
+- **`throughput`** — Sustained batch generation.
+
+Quantization, hardware, and GPU count are fixed for the life of a deployment. To move a running
+model onto a different profile, create a new deployment with the new config and
+[shift traffic](traffic-routing.md) over.
+
+## Decoding optimizations
+
+Speculative decoding and other decoding optimizations are properties of the config, not the
+deployment. When a config declares a speculative-decoding draft, list/get responses include
+`draftModel` (the draft model's resource name); configs without it omit the field. You cannot set a
+speculator on the deployment.
+
+Speculative decoding raises average throughput but can add tail-latency spikes. Latency-sensitive
+workloads should pick a `latency`-optimization config instead.
+
+The config's `optimization` selector — `balanced`, `throughput`, or `latency` — sets the serving
+profile. Together publishes new config revisions over time (with new `cr_...` IDs); a deployment
+pins its revision, so hardware and engine don't change underneath it.

--- a/skills/together-dedicated-endpoints/references/traffic-routing.md
+++ b/skills/together-dedicated-endpoints/references/traffic-routing.md
@@ -1,0 +1,453 @@
+# Traffic routing (v2)
+
+DMI v2 introduces multiple ways to route inference across the deployments behind a single endpoint:
+basic traffic splits, A/B experiments, shadow experiments, and metric-gated rollouts. None of these
+exist on v1 endpoints.
+
+## Contents
+
+- [How routing works](#how-routing-works)
+- [Stickiness](#stickiness)
+- [Basic weights](#basic-weights)
+- [Split traffic](#split-traffic)
+- [A/B tests (`abx_...`)](#ab-tests-abx_)
+- [Shadow experiments (`exp_...`)](#shadow-experiments-exp_)
+- [Rollouts (`rol_...`)](#rollouts-rol_)
+- [Cross-feature rules](#cross-feature-rules)
+
+## How routing works
+
+The endpoint resolves each request through a sequence of sampling decisions:
+
+1. **Traffic split** — Among the deployments in the split, sample a candidate in proportion to
+   capacity (weight × ready replicas).
+2. **A/B test** — If the candidate is the control of an active A/B experiment, re-sample among
+   control + variants by the configured percentages.
+3. **Route** — Send the request to a cluster within the resolved deployment.
+
+Shadow experiments sit outside this path: they copy a sampled fraction of live traffic to target
+deployments for observation without changing which deployment serves the caller.
+
+## Stickiness
+
+Routing is deterministic per request, not randomly drawn each time. The endpoint derives a
+**sampling key** and always routes requests with the same key to the same deployment (as long as
+the traffic split is stable). This is how DMI keeps prompt caches warm.
+
+Key precedence:
+
+1. `prompt_cache_key` (recommended: set it explicitly to pin a conversation's turns together).
+2. Otherwise `user`.
+3. Otherwise a key derived from request content.
+
+Stickiness holds until the traffic split changes (weight edit, deployment added or removed); some
+keys reassign when routing changes.
+
+## Basic weights
+
+Every deployment on an endpoint has a weight in the endpoint's traffic split. A weight is a
+non-negative, finite ratio — not a percentage — and each deployment's share is proportional to its
+weight × ready replicas.
+
+Set with `tg beta endpoints update` passing the **deployment ID**; the CLI resolves the parent
+endpoint and preserves the other deployments' weights:
+
+```bash
+tg beta endpoints update dep_abc123 --traffic-weight 1     # add / update
+tg beta endpoints update dep_def456 --traffic-weight 0     # remove from split entirely
+```
+
+`weight = 0` unsets the deployment from the split (the deployment keeps running). A deployment
+draws no traffic if its weight is `0`, it's absent from the split, or it has zero ready replicas.
+An endpoint with no routable deployment returns HTTP `400 endpoint_not_configured`.
+
+## Split traffic
+
+Split traffic across multiple deployments on one endpoint for high availability, staged migration,
+or independent scaling per model version.
+
+```bash
+tg beta endpoints update dep_abc123 --traffic-weight 70
+tg beta endpoints update dep_def456 --traffic-weight 30
+```
+
+Rules:
+
+- Weights are **relative capacity**, not percentages. `70 / 30` is the same as `7 / 3`.
+- Two deployments with the same weight but different ready-replica counts do NOT receive equal
+  traffic.
+- Weights are remembered when a deployment scales to zero and reapply when it scales back up.
+- **Shift traffic between deployments by rescaling** (change replica counts) rather than editing
+  weights, so the endpoint's declared capacity split stays stable.
+
+## A/B tests (`abx_...`)
+
+An A/B test holds a fixed **control / variant** split under one endpoint for measured comparison on
+live traffic. The test subdivides only the control's share of traffic; every other deployment in
+the split is unaffected.
+
+### Requirements
+
+- A `READY` control deployment that is receiving traffic (i.e. in the endpoint's traffic split).
+- Variants must be **excluded** from the endpoint's traffic split (weight `0` or unset). A variant
+  with a non-zero weight causes the test to fail to start.
+- Exactly one control and 1–19 variants (up to 20 members total).
+- Percentages across all members (including the control) sum to `100`.
+
+### Start (CLI)
+
+The CLI's `ab` command creates the variant deployment for the model you pass and starts the
+experiment, assigning `--percent` to the variant and the remainder to the control:
+
+```bash
+tg beta endpoints ab ml_CbJNwQC2ZqCU2iFT3mrCh \
+  --control dep_control123 \
+  --percent 5 \
+  --name sampling-tweak-v1
+```
+
+Save the returned experiment ID (`abx_...`) and the variant deployment ID (`dep_...`).
+
+### Ramp
+
+Only the SDK/API can change existing members' percentages. `members` is replaced whole; re-list
+every member:
+
+```python
+client.beta.endpoints.ab_experiments.update(
+    "abx_abc123",
+    endpoint_id="ep_abc123",
+    project_id=project_id,
+    members=[
+        {"deployment_id": "dep_control123",
+         "role": "AB_EXPERIMENT_MEMBER_ROLE_CONTROL", "percent": 90},
+        {"deployment_id": "dep_variant456",
+         "role": "AB_EXPERIMENT_MEMBER_ROLE_VARIANT", "percent": 10},
+    ],
+)
+```
+
+### Add more variants
+
+Run `ab` again with the same control. Each `ab` call carves the new variant's percentage out of
+the control's share and leaves existing variants untouched:
+
+```bash
+tg beta endpoints ab ml_Zk7pR2mQ9sT4vU6yB1nD3 \
+  --control dep_control123 \
+  --percent 10
+```
+
+The control's share cannot drop below `1%`.
+
+### Promote and delete
+
+Promote a winning variant by editing the endpoint's traffic split so the winner takes all traffic:
+
+```bash
+tg beta endpoints update dep_control123 --traffic-weight 0
+tg beta endpoints update dep_variant456 --traffic-weight 1
+tg beta endpoints rm abx_abc123          # ends the managed control/variant split
+```
+
+Deleting an A/B test immediately returns all traffic to the control (or the promoted variant).
+Clean up member deployments in the usual [teardown order](api-reference.md#smart-delete-v2).
+
+## Shadow experiments (`exp_...`)
+
+Shadow experiments mirror a fraction of live endpoint traffic to one or more target deployments for
+observation. Targets never return responses to the caller.
+
+Use shadow to warm a new deployment under real load, stress-test a config change, or gather
+comparative metrics before you shift real traffic.
+
+### Requirements
+
+- A running endpoint under live traffic.
+- One or more candidate deployments to shadow to. Each target must be **excluded** from the
+  endpoint's traffic split (weight `0` or unset).
+
+### Sampling strategies
+
+| Strategy | Flags | Behavior |
+| --- | --- | --- |
+| `uniform` | `--rate 0.0…1.0` | Fixed fraction of all requests, sampled at random. |
+| `key_based` | `--rate 0.0…1.0 --key <field>` | Fixed fraction of distinct key values (sticky). |
+| `adaptive_uniform` | `--target-qps <N> [--window <s>]` | Auto-tunes uniform rate to approach a target QPS. |
+| `adaptive_key_based` | `--target-qps <N> --key <field> [--window <s>]` | Auto-tunes key-based rate to approach a target QPS. |
+
+`--key` names a top-level field in the request body (for example `body.user` or
+`body.prompt_cache_key`), not a nested path. Requests missing that field are sampled at random.
+
+`--target-qps` is an approximate throttle, not a hard cap. Actual mirrored volume can exceed the
+target as the endpoint scales up. Use `uniform` when you need a predictable fraction.
+
+Setting `--rate 0` mirrors nothing — a way to pause without deleting.
+
+### Create (CLI)
+
+```bash
+tg beta endpoints shadow \
+  --endpoint ep_abc123 \
+  --model ml_CbJNwQC2ZqCU2iFT3mrCh \
+  --rate 0.1 \
+  --name candidate-v2
+```
+
+The CLI creates a fresh shadow deployment from the model and wires it up as a target. Note the
+experiment ID (`exp_...`) from the response. `name` is immutable and unique per endpoint.
+
+### Adaptive and key-based examples
+
+```bash
+tg beta endpoints shadow --endpoint ep_abc123 --model ml_abc123 \
+  --rate 0.05 --key body.user --name cohort-safety
+
+tg beta endpoints shadow --endpoint ep_abc123 --model ml_abc123 \
+  --target-qps 5.0 --name throttled-canary
+```
+
+### Update, target management, and stop
+
+- **Retune sampling** — Fetch the experiment, pass its current `etag` back in an update. A stale
+  `etag` returns `409 ABORTED`.
+- **Add a target** — Adds fan-out. One sampling decision fans out to every target, multiplying
+  mirrored volume across targets.
+- **Pause without deleting** — Update `source` and set `rate` to `0`.
+- **Stop** — Delete the experiment (cascade-deletes targets), or remove all targets so the
+  experiment goes `INACTIVE`.
+
+```bash
+tg beta endpoints rm exp_abc123
+```
+
+Propagation: new or updated shadow experiments take effect within about 30–60 seconds. Deletes
+stop mirroring within the same window. Mirrored requests are never sampled and mirrored again;
+shadow loops are impossible.
+
+### Response fields
+
+| Field | Description |
+| --- | --- |
+| `id` | `exp_...` experiment identifier. |
+| `endpoint_id` | Endpoint whose traffic is sampled. |
+| `name` | Unique within the endpoint. Immutable after create. |
+| `source` | Sampling configuration. |
+| `targets` | Inline on `Get`. |
+| `state` | Derived: `ACTIVE` when at least one target exists, `INACTIVE` otherwise. Not settable. |
+| `etag` | Version tag for optimistic concurrency on update/delete. |
+| `created_by` / `created_at` / `updated_at` | Provenance. |
+
+### Limits
+
+- Up to 100 inline targets on create; add more via target methods.
+- `name` up to 256 characters, on experiments and targets.
+- List `limit` defaults 50, max 500.
+
+## Rollouts (`rol_...`)
+
+A rollout shifts traffic from a source deployment to a target deployment under the same endpoint,
+optionally gated on live metrics.
+
+### Strategies
+
+Pick one strategy per rollout:
+
+| Strategy | Traffic pattern | Use when |
+| --- | --- | --- |
+| **Canary** | Staged percentage ladder (e.g. 25%, 50%, 75%, 100%). Source drains stepwise. | Gradual, metric-gated exposure. Safest for production. |
+| **Blue-green** | Single 0 → 100 cutover after target is ready. | Atomic cutover with capacity for both sides at full size. |
+| **Rolling** | Replica-by-replica batch swap (target +1 / source −1). | Preserve GPU capacity; no traffic ramp needed. |
+
+Metric gates are **canary-only**. Blue-green and rolling reject a `metrics` block.
+
+### Requirements
+
+- A source deployment referenced in the endpoint's traffic split.
+- A target deployment with at least one replica, `READY`. Don't start a rollout with target bounds
+  at `0/0` — traffic can shift before a replica is ready and cause `deployment_stopped` errors.
+- Target project in good billing standing (rechecked at each target scale-up; `ENTITLEMENT_LAPSED`
+  otherwise).
+
+### Create (CLI)
+
+```bash
+# Canary (defaults: steps 10,50,100 over 10m intervals)
+tg beta endpoints rollout dep_target456 --from dep_source123 --canary
+
+# Blue-green (default when no strategy flag is set)
+tg beta endpoints rollout dep_target456 --from dep_source123 --blue-green
+
+# Rolling
+tg beta endpoints rollout dep_target456 --from dep_source123 --rolling
+```
+
+Customize a canary ladder with `--steps` (e.g. `--steps 25,50,75,100`) and `--interval` (e.g.
+`--interval 10m`). Pass `--source-cleanup keep` to keep the source at its replica count after
+completion instead of draining.
+
+Save the returned rollout ID (`rol_...`).
+
+### Metric gates (canary-only)
+
+Only the SDK/API creates a metric-gated rollout. Metric gates evaluate after each step's soak
+window and either advance or pause the rollout.
+
+```python
+rollout = client.beta.endpoints.rollouts.create(
+    "ep_abc123",
+    project_id=project_id,
+    source_deployment_id="dep_source123",
+    target_deployment_id="dep_target456",
+    canary={
+        "steps": [
+            {"traffic": 25, "replicas": 1},
+            {"traffic": 50, "replicas": 2},
+            {"traffic": 75, "replicas": 3},
+            {"traffic": 100, "replicas": 4},
+        ],
+        "step_interval": "390s",
+    },
+    metrics=[
+        {
+            "name": "serving_latency",
+            "stat": "METRIC_STAT_TYPE_PERCENTILE",
+            "percentile": 95,
+            "regression_check": {
+                "max_regression_percent": 50,
+                "direction": "REGRESSION_DIRECTION_HIGHER_IS_WORSE",
+            },
+            "window": "300s",
+        }
+    ],
+    source_cleanup="SOURCE_CLEANUP_POLICY_DRAIN",
+    final_source_replicas=0,
+    final_target_replicas=4,
+)
+client.beta.endpoints.rollouts.start(
+    rollout.id, project_id=project_id, endpoint_id="ep_abc123"
+)
+```
+
+`final_target_replicas` must be at least `1`. Steps declare the traffic ladder and the target
+replica count at each step; metrics declare the gate checked after each soak.
+
+Each metric rule has:
+
+- `name` — a **gate catalog key** (not a raw Prometheus series). See table below.
+- `stat` and `percentile` — `METRIC_STAT_TYPE_PERCENTILE` (with `percentile`) for histograms,
+  `METRIC_STAT_TYPE_AVG` for ratios / gauges.
+- Exactly one of `regression_check` (relative-to-source, with `max_regression_percent` and
+  `direction`) or `threshold_check` (absolute, with `value` and `operator` from
+  `THRESHOLD_OPERATOR_{GT,GTE,LT,LTE}`). Latency `value` is in **milliseconds**.
+- `window` — Lookback duration in seconds. Use `300s` for histogram percentiles.
+- Rules are ANDed; any regression or unavailability pauses the step.
+
+Supported metric catalog:
+
+| `name` | Type | Meaning | `stat` |
+| --- | --- | --- | --- |
+| `serving_latency` | Histogram | Engine request duration. Preferred latency gate. | `AVG`, `PERCENTILE` |
+| `router_latency` | Histogram | Router per-attempt latency. Bimodal — gate on `PERCENTILE` ≥ 95. | `AVG`, `PERCENTILE` |
+| `router_error_rate` | Ratio | Router 5xx / total responses. | `AVG` |
+| `inflight_requests` | Gauge | In-flight on the target pods. | `AVG` |
+
+Higher is worse for all four. For reliability gates, prefer `serving_latency` and
+`router_error_rate`, which are keyed by deployment ID and present whenever the target takes
+traffic.
+
+Metric gates require live traffic on the target. Without it, samples never accumulate, the gate
+reports `METRICS_UNAVAILABLE`, and the rollout pauses.
+
+### `inflight_requests` normalization
+
+For `regression_check` on `inflight_requests` only:
+
+- Compares **per ready replica**. `sourceValue`, `targetValue`, and `reason` are per-replica, not
+  totals, and won't match a dashboard's summed count. `reason` appends `(values per ready replica)`.
+- `threshold_check` on `inflight_requests` stays on raw totals.
+- **Low-signal baselines are floored** at one request per replica. Trickle traffic can't pause or
+  abort a rollout on its own; if a regression still fires, the gate re-evaluates before acting and
+  the `reason` also notes `(source baseline floored at 1 per replica)`.
+
+### Choose a `window`
+
+`window` is the lookback for the metric query, in seconds. Use `300s` for histogram percentiles.
+Short windows (like `60s`) sit inside ingestion lag and produce untrustworthy percentiles. Keep
+`step_interval` ≥ `window + ~90s` so the metric can settle.
+
+### Manage a running rollout
+
+| CLI | SDK | Effect |
+| --- | --- | --- |
+| `rollout <rol_id> --pause [--reason "..."]` | `rollouts.pause` | Hold at current step; honored at next step boundary. |
+| `rollout <rol_id> --continue` | `rollouts.resume` | Resume from current step. |
+| `rollout <rol_id> --complete` | `rollouts.promote` | Fast-forward to final step; all traffic to target. |
+| `rollout <rol_id> --abort [--reason "..."]` | `rollouts.abort` | Cancel; traffic reverts to source. Terminal, active-only. |
+
+### Pause categories
+
+`SYSTEM_PAUSED` rollouts carry a `status.condition.category` — use it, not the free-text message,
+to decide next steps:
+
+| Category | Meaning | Typical action |
+| --- | --- | --- |
+| `METRIC_REGRESSION` | Metric gate detected regression vs. source. | Abort. |
+| `METRICS_UNAVAILABLE` | Load gap; not enough samples. | Restore load, then resume. |
+| `TARGET_NOT_READY` | Target didn't become ready in time. | Investigate, then resume or abort. |
+| `SOURCE_NOT_DRAINED` | Source still has replicas that should have drained. | Wait or investigate. |
+| `HEALTH_REGRESSION` | Health check failed during soak. | Abort. |
+| `CAPACITY_EXHAUSTED` | Not enough fleet capacity for requested replicas. | Wait, then resume. |
+| `ROUTING_ERROR` | Invalid routing configuration hit during shift. | Fix routing, then resume or abort. |
+| `DEPENDENCY_OUTAGE` | Platform dependency unreachable too long. | Wait, then resume. |
+| `POLICY_INFEASIBLE` | Autoscaling ceiling below the replica floor the step requires. | Fix bounds, then resume. |
+| `UNDER_SERVED` | Ready capacity dropped below split requirements. | Restore capacity or reduce split, then resume. |
+| `ENTITLEMENT_LAPSED` | Billing/entitlement check failed before a target scale-up. | Resolve billing, then resume or abort. |
+| `ABORTED_BY_OPERATOR` | Operator aborted. | Terminal. |
+| `INTERNAL` | Unexpected platform error. | Contact support with rollout ID and message. |
+
+### Rollout state machine
+
+`PENDING → RUNNING ↔ STABILIZING → COMPLETED` on success, with side branches into `PAUSED`,
+`SYSTEM_PAUSED`, `ABORTING`, `ABORTED`.
+
+| State | Meaning |
+| --- | --- |
+| `PENDING` | Created, not yet started. |
+| `RUNNING` | Actively shifting traffic. |
+| `STABILIZING` | Holding at a step's traffic level before moving to the next. |
+| `PAUSED` | Operator-paused. Traffic holds. |
+| `SYSTEM_PAUSED` | Platform-paused for review. Read `status.condition.category`. |
+| `ABORTING` | Cancellation in progress; reverting to source. |
+| `ABORTED` | Terminal. Traffic on source. |
+| `COMPLETED` | Terminal. Traffic on target; source drained. |
+
+### Roll back after completion
+
+Once a rollout is `COMPLETED`, the source is drained — you cannot abort. To revert, run a new
+rollout in reverse: the now-serving target becomes the source, and the old deployment becomes the
+target.
+
+### Delete
+
+Delete pending or terminal rollouts via the SDK (`rm` doesn't accept `rol_...`):
+
+```python
+client.beta.endpoints.rollouts.delete(
+    "rol_abc123", project_id=project_id, endpoint_id="ep_abc123",
+)
+```
+
+An endpoint can have only one active rollout at a time. Finish or abort the existing rollout
+before creating another.
+
+## Cross-feature rules
+
+- A deployment used as a **shadow target** cannot also serve live traffic. Attempting to give it a
+  non-zero weight in the traffic split returns:
+  `the deployment is a shadow experiment target and cannot serve live traffic; remove the shadow target first`.
+- A deployment used as an **A/B variant** must be excluded from the traffic split.
+- A **rollout** requires the source to be in the traffic split; against a source that isn't
+  referenced in the split, the rollout starts but shifts nothing.
+- **Deletion order matters**: stop deployments before deleting them, and drop their traffic-split
+  weight to `0` first (or use `tg beta endpoints rm dep_...`, which auto-detaches).

--- a/skills/together-dedicated-endpoints/scripts/deploy_finetuned.py
+++ b/skills/together-dedicated-endpoints/scripts/deploy_finetuned.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python3
 """
-Together AI -- Deploy a Fine-tuned Model on a Dedicated Endpoint (v2 SDK)
+Together AI -- Deploy a Fine-tuned Model on a v1 Dedicated Endpoint (legacy).
 
-Deploy a fine-tuned model as a dedicated endpoint, wait for it to become
-ready, and optionally run inference or tear down the endpoint.
+Deploy a fine-tuned model as a **v1** dedicated endpoint, wait for it to
+become ready, and optionally run inference or tear down the endpoint. Uses
+the top-level `client.endpoints.*` SDK surface, which works only against v1
+endpoints.
 
 Fine-tuned models may require larger hardware than the base parameter count
 suggests (e.g. 4x H100 for an 8B model). The script validates the chosen
 hardware against eligible configs before creating the endpoint.
+
+For **v2 (dedicated model inference)** fine-tuned deployment, use:
+
+    tg beta endpoints deploy <model_id> --endpoint <name> --config <cr_...>
+
+See references/models-and-configs.md for the full v2 upload + deploy flow,
+and scripts/deploy_v2.sh for an end-to-end v2 walkthrough.
 
 Usage:
     python deploy_finetuned.py list-jobs

--- a/skills/together-dedicated-endpoints/scripts/deploy_v2.sh
+++ b/skills/together-dedicated-endpoints/scripts/deploy_v2.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Together AI Dedicated Model Inference (v2) -- End-to-end CLI walkthrough
+#
+# Deploys a supported model on DMI v2, waits for the deployment to become ready,
+# sends a chat completion, and tears the deployment down.
+#
+# Every management operation goes through the `tg beta` CLI (Together CLI 2.24.0+).
+# The v2 Python/TypeScript SDK surface (client.beta.endpoints.*) is still being
+# published, so this script uses the CLI plus curl for inference.
+#
+# Usage:
+#   ./deploy_v2.sh                      # runs the default demo (google/gemma-4-E4B-it)
+#   MODEL=zai-org/GLM-5.2 ./deploy_v2.sh
+#
+# Requirements:
+#   uv tool install "together[cli]"     # or: pip install together
+#   export TOGETHER_API_KEY=your_key
+#   # Optional: pin the project explicitly
+#   export TOGETHER_PROJECT_ID=proj_...
+#
+# Notes:
+#   - Set CONFIG_ID when the chosen model has more than one deployment profile.
+#     A bare `tg beta endpoints deploy <model>` errors with the available
+#     profiles when a config is required.
+#   - Set NO_TEARDOWN=1 to keep the endpoint after inference.
+
+set -euo pipefail
+
+MODEL="${MODEL:-google/gemma-4-E4B-it}"
+ENDPOINT_NAME="${ENDPOINT_NAME:-dmi-demo-$(date +%s)}"
+MIN_REPLICAS="${MIN_REPLICAS:-1}"
+MAX_REPLICAS="${MAX_REPLICAS:-1}"
+CONFIG_ID="${CONFIG_ID:-}"
+PROMPT="${PROMPT:-What is 2 + 2?}"
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+POLL_TIMEOUT="${POLL_TIMEOUT:-1200}"
+NO_TEARDOWN="${NO_TEARDOWN:-}"
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1"; exit 1; }
+}
+require tg
+require jq
+require curl
+
+: "${TOGETHER_API_KEY:?Set TOGETHER_API_KEY before running}"
+
+echo "=== whoami ==="
+tg whoami
+
+echo
+echo "=== deploy $MODEL as endpoint $ENDPOINT_NAME ==="
+deploy_args=(
+  beta endpoints deploy "$MODEL"
+  --endpoint "$ENDPOINT_NAME"
+  --min-replicas "$MIN_REPLICAS"
+  --max-replicas "$MAX_REPLICAS"
+  --json
+)
+if [ -n "$CONFIG_ID" ]; then
+  deploy_args+=(--config "$CONFIG_ID")
+fi
+
+deploy_json=$(tg "${deploy_args[@]}")
+echo "$deploy_json" | jq .
+
+endpoint_id=$(echo "$deploy_json" | jq -r '.endpoint.id // .id // empty')
+deployment_id=$(echo "$deploy_json" | jq -r '.deployment.id // .deployments[0].id // empty')
+inference_name=$(echo "$deploy_json" | jq -r '.endpoint.name // .name // .inferenceName // empty')
+
+if [ -z "$endpoint_id" ] || [ -z "$deployment_id" ]; then
+  echo "Could not parse endpoint or deployment ID from deploy output." >&2
+  exit 1
+fi
+
+echo
+echo "endpoint_id=$endpoint_id"
+echo "deployment_id=$deployment_id"
+echo "inference_name=$inference_name"
+
+echo
+echo "=== wait for DEPLOYMENT_STATE_READY (up to ${POLL_TIMEOUT}s) ==="
+elapsed=0
+while [ "$elapsed" -lt "$POLL_TIMEOUT" ]; do
+  status_json=$(tg beta endpoints get "$endpoint_id" --json)
+  state=$(echo "$status_json" | jq -r --arg dep "$deployment_id" \
+    '.deployments[] | select(.id == $dep) | .status.state // empty')
+  ready=$(echo "$status_json" | jq -r --arg dep "$deployment_id" \
+    '.deployments[] | select(.id == $dep) | .status.readyReplicas // 0')
+  message=$(echo "$status_json" | jq -r --arg dep "$deployment_id" \
+    '.deployments[] | select(.id == $dep) | .status.message // ""')
+  printf "  state=%s ready=%s message=%q (%ss)\n" "$state" "$ready" "$message" "$elapsed"
+
+  case "$state" in
+    DEPLOYMENT_STATE_READY) break ;;
+    DEPLOYMENT_STATE_FAILED)
+      echo "Deployment failed. Full status:" >&2
+      echo "$status_json" | jq . >&2
+      exit 1
+      ;;
+  esac
+
+  sleep "$POLL_INTERVAL"
+  elapsed=$((elapsed + POLL_INTERVAL))
+done
+
+if [ "$state" != "DEPLOYMENT_STATE_READY" ]; then
+  echo "Deployment did not reach READY within ${POLL_TIMEOUT}s (last state: $state)." >&2
+  exit 1
+fi
+
+echo
+echo "=== send a chat completion to $inference_name ==="
+curl -s -X POST https://api-inference.together.ai/v1/chat/completions \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg m "$inference_name" --arg p "$PROMPT" '{
+    model: $m,
+    messages: [{role: "user", content: $p}],
+    max_tokens: 256
+  }')" | jq .
+
+if [ -n "$NO_TEARDOWN" ]; then
+  echo
+  echo "NO_TEARDOWN set; leaving endpoint $endpoint_id (deployment $deployment_id) running."
+  echo "Scale down later with:"
+  echo "  tg beta endpoints update $deployment_id --min-replicas 0 --max-replicas 0"
+  echo "Or delete both resources with:"
+  echo "  tg beta endpoints rm $endpoint_id --force"
+  exit 0
+fi
+
+echo
+echo "=== teardown: delete endpoint $endpoint_id ==="
+tg beta endpoints rm "$endpoint_id" --force
+echo "Done."

--- a/skills/together-dedicated-endpoints/scripts/manage_endpoint.py
+++ b/skills/together-dedicated-endpoints/scripts/manage_endpoint.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 """
-Together AI Dedicated Endpoints -- Create, Monitor, Use, Stop (v2 SDK)
+Together AI Dedicated Endpoints (v1 legacy) -- Create, Monitor, Use, Stop.
 
-Full lifecycle: list hardware, create endpoint, wait for ready,
-run inference, then stop or delete.
+Full lifecycle for a **v1** dedicated endpoint: list hardware, create endpoint,
+wait for ready, run inference, then stop or delete. Uses the top-level
+`client.endpoints.*` SDK surface, which continues to work only against v1
+endpoints.
+
+For **v2 (dedicated model inference)** workflows, use the Together CLI:
+
+    tg beta endpoints deploy <model> --endpoint <name>
+    tg beta endpoints update <deployment_id> --min-replicas 0 --max-replicas 0
+    tg beta endpoints rm <endpoint_id> --force
+
+See scripts/deploy_v2.sh for an end-to-end v2 walkthrough, or
+references/api-reference.md for the full v2 surface. New endpoints should
+target v2; v1 remains supported through the end of 2026.
 
 Usage:
     python manage_endpoint.py list-hardware --model Qwen/Qwen3.5-9B-FP8

--- a/skills/together-dedicated-endpoints/scripts/manage_endpoint.ts
+++ b/skills/together-dedicated-endpoints/scripts/manage_endpoint.ts
@@ -1,9 +1,21 @@
 #!/usr/bin/env -S npx tsx
 /**
- * Together AI Dedicated Endpoints -- Create, Monitor, Use, Stop
+ * Together AI Dedicated Endpoints (v1 legacy) -- Create, Monitor, Use, Stop.
  *
- * Full lifecycle: list hardware, create endpoint, wait for ready,
- * run inference, then stop/delete.
+ * Full lifecycle for a **v1** dedicated endpoint: list hardware, create endpoint,
+ * wait for ready, run inference, then stop/delete. Uses the top-level
+ * `together.endpoints.*` SDK surface, which continues to work only against v1
+ * endpoints.
+ *
+ * For **v2 (dedicated model inference)** workflows, use the Together CLI:
+ *
+ *   tg beta endpoints deploy <model> --endpoint <name>
+ *   tg beta endpoints update <deployment_id> --min-replicas 0 --max-replicas 0
+ *   tg beta endpoints rm <endpoint_id> --force
+ *
+ * See scripts/deploy_v2.sh for an end-to-end v2 walkthrough, or
+ * references/api-reference.md for the full v2 surface. New endpoints should
+ * target v2; v1 remains supported through the end of 2026.
  *
  * Usage:
  *   npx tsx manage_endpoint.ts

--- a/skills/together-dedicated-endpoints/scripts/upload_custom_model.py
+++ b/skills/together-dedicated-endpoints/scripts/upload_custom_model.py
@@ -1,9 +1,22 @@
 #!/usr/bin/env python3
 """
-Together AI -- Upload and Deploy a Custom Model (v2 SDK)
+Together AI -- Upload and Deploy a Custom Model on v1 (legacy).
 
-Upload a custom model from Hugging Face or S3, wait for the upload job
-to complete, and optionally deploy it on a dedicated endpoint.
+Upload a custom model from Hugging Face or S3 through the **v1** model-upload
+endpoint (`POST /v1/models`), wait for the upload job to complete, and
+optionally deploy it on a v1 dedicated endpoint. Uses `client.models.upload`
+and `client.endpoints.create`, which only work against v1.
+
+For **v2 (dedicated model inference)** custom uploads use the CLI:
+
+    tg beta models create <name> --base-model <ml_...> [--type adapter]
+    tg beta models remote-uploads create <ml_...> --from <hf_or_s3_url>
+    tg beta models remote-uploads retrieve <job_id>
+    tg beta endpoints deploy <ml_...> --endpoint <name> --config <cr_...>
+
+Note: v2 uploads must be fine-tuned variants of a supported base architecture
+(v1 accepted arbitrary architectures). See references/models-and-configs.md
+for the v2 walkthrough.
 
 Usage:
     python upload_custom_model.py --model-name my-custom-model --hf-repo your-org/your-model --hardware 2x_nvidia_h100_80gb_sxm


### PR DESCRIPTION
Sync the `together-dedicated-endpoints` skill with the DE 2.0 (dedicated model inference) documentation rewrite merged in [mintlify-docs#991](https://github.com/togethercomputer/mintlify-docs/pull/991).

## Changed docs files that triggered this sync

- `docs/dedicated-endpoints/overview.mdx` — rewritten for DMI 2.0
- `docs/dedicated-endpoints/quickstart.mdx` — CLI-first `tg beta endpoints deploy` walkthrough
- `docs/dedicated-endpoints/manage.mdx` — new endpoint/deployment lifecycle
- `docs/dedicated-endpoints/scaling.mdx` — new autoscaling metrics and windows
- `docs/dedicated-endpoints/concepts.mdx` (new) — resource model, cold starts, sticky routing
- `docs/dedicated-endpoints/configs.mdx` (new) — deployment profiles and configs
- `docs/dedicated-endpoints/pricing.mdx` (new) — DMI billing and instance-type table
- `docs/dedicated-endpoints/requests.mdx` (new) — inference at `api-inference.together.ai/v1`
- `docs/dedicated-endpoints/route-traffic.mdx` (new) — routing pipeline + stickiness
- `docs/dedicated-endpoints/split-traffic.mdx` (new) — weighted traffic splits
- `docs/dedicated-endpoints/ab-tests.mdx` (new) — A/B experiments (`abx_`)
- `docs/dedicated-endpoints/shadow-experiments.mdx` (new) — shadow experiments (`exp_`)
- `docs/dedicated-endpoints/rollouts.mdx` (new) — metric-gated rollouts (`rol_`)
- `docs/dedicated-endpoints/monitoring.mdx` (new) — events feed + Prometheus metrics endpoint
- `docs/dedicated-endpoints/custom-models.mdx` — v2 fine-tuned model upload flow
- `docs/dedicated-endpoints/adapter.mdx` — v2 LoRA adapter upload flow
- `docs/dedicated-endpoints/models.mdx` — new supported-models catalog with deployment profiles
- `docs/dedicated-endpoints/migrate-from-v1.mdx` (new) — v1 → v2 migration guide
- `docs/dedicated-endpoints/v1/*` (new) — v1 legacy pages retained under `/v1/`

## Skill changes

- **`SKILL.md`** rewritten to make v2 (DMI) the default while noting v1 remains supported through the end of 2026. Quick-routing menu adds the v2 CLI workflows (deploy, split, A/B, shadow, rollout, custom-model + LoRA upload). High-signal rules updated for CLI 2.24.0+, project scope, `ep_/dep_` IDs, `min:0` requires `max:0`, autoscaling metric units, canary-only metric gates, and prompt caching being on by default.
- **`references/api-reference.md`** restructured v2-first: DMI resource model, full `tg beta` surface, deploy flags, deployment states, autoscaling metrics + rate limits + stabilization windows, configs and profiles, instance types + headroom, model/adapter uploads, observability (events feed + Prometheus-compatible metrics endpoint), smart-delete rules by ID prefix, and a concise v1 legacy section with the command mapping table.
- **`references/traffic-routing.md`** (new) documents the full v2 routing surface: how routing works (traffic split → A/B re-sample → route), stickiness via `prompt_cache_key`, basic weights and split-traffic semantics, A/B tests with ramp/promote/delete, shadow experiments (all four sampling strategies), and rollouts with canary/blue-green/rolling strategies, metric gates, per-replica normalization for `inflight_requests`, pause categories, state machine, and roll-back guidance.
- **`references/models-and-configs.md`** (new) covers architecture / weight / config layering, `tg beta models public` and `tg beta models configs` responses, the v2 fine-tuned model upload walkthrough (create → upload → poll → deploy), LoRA adapter uploads with the `--type adapter` flag, the doubled-slug naming pitfall, and speculative-decoding as a config property.
- **`references/hardware-options.md`** adds the new v2 instance-type IDs (`1xnvidia-h100-80gb`, `1xnvidia-h200-141gb`, `1xnvidia-b200-180gb`, `1xnvidia-gb300-280gb`, `1xnvidia-b300-280gb`), refreshes the pricing table (H100 $5.49/hr, B200 $8.99/hr, others contact-sales), adds the DMI vs serverless break-even note, and keeps the v1 underscore hardware IDs / v1 SDK query examples for legacy users.
- **`references/dedicated-models.md`** adds `tg beta models public --product DEDICATED` as the primary listing method, preserves the current model snapshot (chat, image, transcription, moderation, rerank), and cross-references the v2 upload workflow.
- **`scripts/deploy_v2.sh`** (new) is an end-to-end v2 CLI walkthrough: `tg beta endpoints deploy`, poll for `DEPLOYMENT_STATE_READY`, send a chat completion to `api-inference.together.ai/v1`, tear down with `tg beta endpoints rm --force`.
- **`scripts/manage_endpoint.py`, `manage_endpoint.ts`, `deploy_finetuned.py`, `upload_custom_model.py`** docstrings marked as v1 (legacy) helpers and pointing users to the v2 CLI equivalents.

## Notes for the reviewer

- The v2 SDK surface (`client.beta.endpoints.*`, `client.beta.models.*`) is still being published; the skill leads with the CLI (`tg beta`) and raw HTTP for automation, and calls this out explicitly in high-signal rules.
- Multi-LoRA serving has moved to the v1 section per the upstream PR; v2 supports single-adapter deployment via `tg beta models create --type adapter`. Both are covered.
- A separate manual effort (skills#50) proposes a new `together-dedicated-model-inference` directory; this sync updates the existing mapped `together-dedicated-endpoints` skill in place per the sync map and hard rules (no new directories).
- Two other DE PRs remain open against v1-shaped content: skills#44 (multi-LoRA hot-swap, now v1-only per upstream) and skills#51 (LoRA-enabled base models table). Neither overlaps with the files touched here.

Generated by the Sync Skills Cursor Automation. Please review before merging.
