### PR TITLE
DX-596-together-gpu-clusters: sync with mintlify-docs#1190

### DIFF
--- a/skills/together-gpu-clusters/references/cluster-management.md
+++ b/skills/together-gpu-clusters/references/cluster-management.md
@@ -354,6 +354,9 @@ Nodes showing "Tests Failed" are not added to the cluster until repaired.
 **Storage:**
 - Storage Performance: `fio` sequential read/write throughput plus a checksummed write/read-back for data-integrity validation against the cluster's shared and local storage tiers.
 
+**Training Performance (preview):**
+- TorchTitan Training: short [TorchTitan](https://github.com/pytorch/torchtitan) benchmark on one or more nodes, measuring steady-state median model FLOPs utilization (MFU) after skipping warmup. Catches grossly degraded nodes that still pass point-in-time diagnostics. **B200 only** (Blackwell, `sm_100`) -- the built-in CUDA and PyTorch stack (PyTorch with FlashAttention 4) does not run on other GPU types. Runtime is about 15 minutes (roughly 9 minutes init, 6 minutes run). Runs on demand and is not part of automatic acceptance testing; thresholds may change while in preview. Default pass threshold: steady-state median MFU >= 30% for Llama 3 8B on a single B200 node (reference ~36.5%). Larger models and multi-node runs use per-run reference values (for example, Llama 3 70B reaches ~38% MFU on 4 nodes).
+
 ### Node Repair
 
 - **Quick Reprovision**: VM recreated on a random physical node (for software issues)


### PR DESCRIPTION
Sync the `together-gpu-clusters` skill with the merged mintlify-docs PR that added the TorchTitan training benchmark active health check.

**Source PR:** togethercomputer/mintlify-docs#1190 -- [TCL-6830]docs: add TorchTitan training health check

**Changed docs files that triggered this sync:**
- `docs/health-checks.mdx`

**Skill changes:**
- Add a new **Training Performance (preview)** subsection to `references/cluster-management.md` under Available Health Check Tests.
- Document the TorchTitan Training test: short TorchTitan benchmark measuring steady-state median MFU after skipping warmup.
- Capture the **B200-only** dependency (Blackwell, `sm_100`) and the built-in CUDA + PyTorch (FlashAttention 4) stack, ~15 min runtime, on-demand-only status, and that it is not part of automatic acceptance testing.
- Record the default pass threshold: steady-state median MFU >= 30% for Llama 3 8B on a single B200 node (reference ~36.5%), with per-run references for larger models/multi-node runs (e.g. Llama 3 70B ~38% on 4 nodes).
- No changes to `SKILL.md`, other references, or scripts -- health check test enumeration lives in `references/cluster-management.md`.

_Generated by the Sync Skills Cursor Automation. Please review before merging._
