### PR TITLE
DX-596-together-evaluations: sync with mintlify-docs#1235

### DIFF
--- a/skills/together-evaluations/SKILL.md
+++ b/skills/together-evaluations/SKILL.md
@@ -44,6 +44,9 @@ through Together AI's evaluation system.
 - **Dataset columns, Jinja2 templates, or pre-generated responses**
   - Read the dataset and template sections in [references/api-reference.md](references/api-reference.md)
   - Use `--eval-column`, `--model-a-column`, or `--model-b-column` in the scripts
+- **Evaluating vision-capable models with image inputs**
+  - Read the Image Inputs section in [references/api-reference.md](references/api-reference.md)
+  - Add an `image_data_urls` column (base64 data URLs) to the dataset; the model and judge must be vision-capable
 - **External providers as judge or target**
   - Read the model-source and provider sections in [references/api-reference.md](references/api-reference.md)
   - Use the scripts with `--judge-model-source external`, `--eval-model-source external`, or compare-side source flags

--- a/skills/together-evaluations/references/api-reference.md
+++ b/skills/together-evaluations/references/api-reference.md
@@ -9,6 +9,7 @@
 - [Result Schemas](#result-schemas)
 - [Evaluation Types](#evaluation-types)
 - [Dataset Format](#dataset-format)
+- [Image Inputs](#image-inputs)
 - [Jinja2 Templates](#jinja2-templates)
 - [External Judges and Targets](#external-judges-and-targets)
 - [Retrieve Evaluation](#retrieve-evaluation)
@@ -464,6 +465,26 @@ For compare jobs with pre-generated outputs, include both candidate columns:
 
 If `model_to_evaluate`, `model_a`, or `model_b` is a model config instead of a column name,
 Together generates the candidate responses at evaluation time.
+
+## Image Inputs
+
+To evaluate vision-capable models, add an `image_data_urls` column to your dataset rows. The
+images are attached to both the model and judge requests alongside the rendered text prompt.
+
+```jsonl
+{"question": "What does this chart show?", "image_data_urls": ["data:image/png;base64,iVBORw0KGgoAAAANSUhEUg..."]}
+```
+
+- `image_data_urls` accepts a single base64-encoded image data URL or a list of them.
+- Only base64 data URLs (`data:image/...;base64,...`) are supported. Remote `http(s)` image
+  URLs are not accepted.
+- Images are automatically translated to each provider's native format: OpenAI-style
+  `image_url` parts for Together serverless, Together dedicated endpoints, and other
+  OpenAI-compatible endpoints; inline image data for Google Gemini; and image blocks for
+  Anthropic. The same dataset works across providers.
+- The model being evaluated (and the judge, if it should also see the image) must be
+  vision-capable. See the vision-capable models section of the evaluations supported-models
+  page in the Together docs.
 
 ## Jinja2 Templates
 


### PR DESCRIPTION
Sync the `together-evaluations` skill with the merged docs PR
[togethercomputer/mintlify-docs#1235](https://github.com/togethercomputer/mintlify-docs/pull/1235)
("MOSH-1142: docs: image inputs for evaluations (image_data_urls)").

## Triggering docs changes

- [`docs/ai-evaluations.mdx`](https://github.com/togethercomputer/mintlify-docs/blob/main/docs/ai-evaluations.mdx) — new "Evaluating with images" subsection documenting the `image_data_urls` dataset column.

## Skill changes

- `references/api-reference.md`: added a new **Image Inputs** section under Dataset Format documenting the `image_data_urls` column (base64 data URL or list), the base64-only constraint (no remote `http(s)` links), automatic per-provider translation (OpenAI-style `image_url` parts, Google Gemini inline image data, Anthropic image blocks), and the vision-capable model/judge requirement.
- `references/api-reference.md`: added the new section to the Contents table of contents.
- `SKILL.md`: added a Quick Routing bullet routing agents to the Image Inputs section when the user wants to evaluate vision-capable models.

Validation:

- `python3 scripts/quick_validate.py skills/together-evaluations` → OK
- `python3 scripts/quality_check.py` → passed

Generated by the Sync Skills Cursor Automation. Please review before merging.
