### PR TITLE
DX-596-together-gpu-clusters: sync with mintlify-docs#1252

### DIFF
--- a/skills/together-gpu-clusters/references/cluster-management.md
+++ b/skills/together-gpu-clusters/references/cluster-management.md
@@ -59,7 +59,7 @@ Two SSH methods are supported. On Slurm clusters with OIDC enabled, pick one fro
 
 | Method | How it works | Requirements |
 |--------|--------------|--------------|
-| **OIDC (Together CLI)** | Browser sign-in that mints a short-lived certificate, executed via `tg beta clusters ssh`. | Together CLI installed (`uv tool install "together[cli]"`, 2.20+, Python 3.10+). Choose a login name when prompted in the cluster UI. No SSH key required. |
+| **OIDC (Together CLI)** | Browser sign-in that mints a short-lived certificate, executed via `tg beta clusters ssh`. | Together CLI installed (`uv tool install "together[cli]"`, 2.23+, Python 3.10+). Choose a login name when prompted in the cluster UI. No SSH key required. |
 | **Key-based** | Standard `ssh -J` proxy jump through the cluster's bastion. | SSH public key uploaded at `api.together.ai/settings/ssh-key` before cluster creation. |
 
 The cluster UI's **Copy SSH command** (worker/compute) and **Copy head node SSH command** (Slurm login) buttons emit a command shaped for the selected method.


### PR DESCRIPTION
Syncs the [together-gpu-clusters](../tree/main/skills/together-gpu-clusters) skill with [togethercomputer/mintlify-docs#1252](https://github.com/togethercomputer/mintlify-docs/pull/1252) ("docs: bump OIDC SSH Together CLI requirement to 2.23+").

## Changed docs that triggered this sync

- \`docs/gpu-clusters-management.mdx\` — bumps the documented Together CLI floor for OIDC SSH from **2.20+** to **2.23+**.

## Skill changes

- \`references/cluster-management.md\`: updated the OIDC (Together CLI) row of the SSH Access requirements table to require **Together CLI 2.23+** (previously 2.20+). Python 3.10+ requirement and \`uv tool install \"together[cli]\"\` install command are unchanged.

No other files touched; no changes to \`SKILL.md\`, \`agents/openai.yaml\`, other references, or scripts. \`scripts/quick_validate.py skills/together-gpu-clusters\` passes.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.