### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#1260

### DIFF
--- a/skills/together-chat-completions/references/models.md
+++ b/skills/together-chat-completions/references/models.md
@@ -16,6 +16,7 @@
 
 | Organization | Model | API String | Context | Quant |
 |-------------|-------|-----------|---------|-------|
+| Thinking Machines | Inkling | `thinkingmachines/Inkling` | 524,288 | NVFP4 |
 | MiniMax | MiniMax M2.7 | `MiniMaxAI/MiniMax-M2.7` | 202,752 | FP4 |
 | Qwen | Qwen3.7 Max | `Qwen/Qwen3.7-Max` | - | - |
 | Qwen | Qwen3.6 Plus | `Qwen/Qwen3.6-Plus` | 1,000,000 | - |


### PR DESCRIPTION
Syncs the `together-chat-completions` skill with [togethercomputer/mintlify-docs#1260](https://github.com/togethercomputer/mintlify-docs/pull/1260) (`MLE-6604: Add thinkingmachines/Inkling to serverless`, merged into `main` at `26be4e9`).

## Triggering docs changes

- `docs/serverless/models.mdx`: added `thinkingmachines/Inkling` to the serverless chat models table (524,288 context, NVFP4 quantization, `$1.00` input / `$4.05` output / `$0.17` cached input per 1M tokens, function calling + structured outputs supported).
- `docs/changelog.mdx`: new-releases entry announcing the model (intentionally unmapped in `sync-map.yaml`; content already reflected via the models page).

## Skill changes

- `skills/together-chat-completions/references/models.md`: add a single row for **Thinking Machines — Inkling** (`thinkingmachines/Inkling`, 524,288 context, NVFP4) to the top of the **Full Chat Model Catalog** table.

No other files changed. `SKILL.md`, other references, and scripts are untouched — this is a catalog addition only, no API-surface or code-pattern changes.

## Fanout notes

`docs/serverless/models.mdx` also matches `together-audio`, `together-images`, and `together-video` via `sync-map.yaml`, but Inkling is a text LLM (per-token pricing, function calling, structured outputs) — not an audio/image/video model — so those skills' catalogs are not affected and no sibling PRs are opened.

Validated with `python3 scripts/quick_validate.py skills/together-chat-completions` (0 errors).

---

Generated by the Sync Skills Cursor Automation. Please review before merging.
