### PR TITLE
DX-596-together-dedicated-endpoints: sync with mintlify-docs#1258

### DIFF
--- a/skills/together-dedicated-endpoints/SKILL.md
+++ b/skills/together-dedicated-endpoints/SKILL.md
@@ -57,7 +57,8 @@ Typical fits:
 
 ## High-Signal Rules
 
-- Python scripts require the Together v2 SDK (`together>=2.0.0`). If the user is on an older version, they must upgrade first: `uv pip install --upgrade "together>=2.0.0"`.
+- **v1 create and restart are disabled.** Creating a new v1 endpoint (`client.endpoints.create(...)`, `POST /v1/endpoints`, `tg endpoints create`) and restarting a stopped or paused v1 endpoint both return `endpoints_v1_create_access_disabled` (HTTP 403). Any new endpoint, and any v1 endpoint that has stopped, must be deployed on v2 using `tg beta endpoints deploy <model_id> --endpoint <name> --config <config_id>` (requires `together>=2.24.0`) or the v2 SDK/API. Existing running v1 endpoints keep serving until further notice. See [Migrate from v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1) for the full migration flow and error-to-fix mapping.
+- Python scripts require the Together v2 SDK (`together>=2.0.0`). If the user is on an older version, they must upgrade first: `uv pip install --upgrade "together>=2.0.0"`. Endpoint creation on v2 additionally requires `together>=2.24.0`.
 - Model eligibility and hardware availability are gating constraints; check them early.
 - Endpoint management uses endpoint IDs, while inference usually uses the endpoint name as `model`.
 - Autoscaling, auto-shutdown, prompt caching, and speculative decoding materially affect operations and cost.
@@ -79,3 +80,4 @@ Typical fits:
 - [Dedicated Endpoints](https://docs.together.ai/docs/dedicated-inference)
 - [Endpoints API](https://docs.together.ai/reference/createendpoint)
 - [Upload and Deploy Custom Models](https://docs.together.ai/docs/custom-models)
+- [Migrate from v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1)

--- a/skills/together-dedicated-endpoints/references/api-reference.md
+++ b/skills/together-dedicated-endpoints/references/api-reference.md
@@ -1,4 +1,7 @@
 # Dedicated Endpoints API Reference
+
+> **Warning: v1 create and restart are disabled.** Creating a new endpoint through the v1 API (`POST /v1/endpoints`, `client.endpoints.create(...)`, `tg endpoints create`) and restarting a stopped or paused v1 endpoint now return `endpoints_v1_create_access_disabled` (HTTP 403). Deploy any new endpoint on v2 with `tg beta endpoints deploy <model_id> --endpoint <name> --config <config_id>` (requires `together>=2.24.0`) or the equivalent v2 SDK/API. Existing running v1 endpoints keep serving until further notice, and the v1 inference, list, retrieve, stop, delete, hardware, and models operations documented below still work for them. See [Migrate from v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1) for the full migration.
+
 ## Contents
 
 - [Endpoints](#endpoints)
@@ -489,6 +492,8 @@ Restricting zones narrows available capacity and can make hardware placement har
 
 | Issue | Solution |
 |-------|----------|
+| `endpoints_v1_create_access_disabled` (HTTP 403) on create | v1 create is disabled. Deploy the model on v2 with `tg beta endpoints deploy <model_id> --endpoint <name> --config <config_id>` (requires `together>=2.24.0`) or the v2 SDK/API. See [Migrate from v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1) |
+| A stopped or paused v1 endpoint won't restart | v1 restart is disabled. Redeploy the same model as a new v2 endpoint; fine-tuned models don't need retraining |
 | Hardware unavailable | Try a different compatible model or retry when capacity changes |
 | Hardware not eligible (404: "not available for this model") | The model only supports specific hardware configs. Run `list_hardware(model=...)` to see eligible options. Fine-tuned models often require larger hardware than their parameter count suggests |
 | Endpoint queued (not starting) | Reduce `min_replicas` to match currently available capacity |


### PR DESCRIPTION
Syncs `together-dedicated-endpoints` with [togethercomputer/mintlify-docs#1258](https://github.com/togethercomputer/mintlify-docs/pull/1258) ([MLE-6650](https://linear.app/together-ai/issue/MLE-6650/update-the-de-v1-ro-v2-migration-docs)).

## Changed docs that triggered this

- `docs/dedicated-endpoints/migrate-from-v1.mdx` — reframes the guide to reflect that v1 create and restart are retired, adds a Troubleshooting section mapping the new `endpoints_v1_create_access_disabled` (HTTP 403) error to its v2 fixes, and hedges the v1 support window to \"until further notice.\"

## Skill changes

- **SKILL.md**: Add a high-signal rule at the top of High-Signal Rules stating v1 create and restart are disabled, listing the API/SDK/CLI surfaces that now return `endpoints_v1_create_access_disabled` (HTTP 403), and pointing agents at the v2 deploy flow (`tg beta endpoints deploy`, `together>=2.24.0`).
- **SKILL.md**: Note the `together>=2.24.0` floor for v2 endpoint creation alongside the existing `together>=2.0.0` base SDK requirement.
- **SKILL.md**: Add the [Migrate from v1](https://docs.together.ai/docs/dedicated-endpoints/migrate-from-v1) guide to Official Docs.
- **references/api-reference.md**: Prepend a Warning callout mirroring the migration guide (v1 create/restart disabled, v2 deploy command, `together>=2.24.0`) so agents reading the reference see the retirement before hitting the v1 Create Endpoint section.
- **references/api-reference.md**: Add two rows to the Troubleshooting table covering the `endpoints_v1_create_access_disabled` error and the \"stopped v1 endpoint won't restart\" case, each linking to the migration guide.

## Not touched

The existing v1 scripts (`scripts/manage_endpoint.py`, `scripts/deploy_finetuned.py`, `scripts/upload_custom_model.py`, `scripts/manage_endpoint.ts`) and the bulk of `references/api-reference.md` still describe the v1 flow. Running v1 endpoints continue to serve until further notice, and #1258 doesn't add or replace any v2 SDK/API surface docs — a full v2 rewrite is a separate effort out of scope for this minimal, PR-scoped sync.

---

Generated by the Sync Skills Cursor Automation. Please review before merging.