### PR TITLE
DX-596-together-chat-completions: sync with mintlify-docs#1269

### DIFF
--- a/skills/together-chat-completions/references/api-parameters.md
+++ b/skills/together-chat-completions/references/api-parameters.md
@@ -357,8 +357,10 @@ typed reasoning fields, or other platform-specific workflows already covered by 
 
 ## Rate Limits & Build Tiers
 
-Serverless rate limits are model-specific and can change based on capacity. Treat response headers
-as the source of truth for the current limit on the model you are calling.
+Serverless rate limits are model-specific and can change based on capacity. Successful requests
+come back without rate-limit headers; when a request is throttled (`429`) the response includes
+`x-ratelimit-reset` with the number of seconds to wait before retrying. Use that value to drive
+backoff.
 
 Current account-level LLM baselines from the official Together AI billing docs:
 
@@ -370,13 +372,14 @@ Current account-level LLM baselines from the official Together AI billing docs:
 | Build Tier 4 | $250 | 4,500 RPM |
 | Build Tier 5 | $1,000 | 6,000 RPM |
 
-Rate-limit headers returned on serverless responses:
+Rate-limit headers only appear on `429 Too Many Requests` responses; successful responses do not
+include them. Header reference:
 
 | Header | Description |
 |--------|-------------|
 | `x-ratelimit-limit` | Maximum request rate currently allowed |
 | `x-ratelimit-remaining` | Remaining request capacity in the current window |
-| `x-ratelimit-reset` | Time until the request window resets |
+| `x-ratelimit-reset` | Seconds to wait before retrying |
 | `x-tokenlimit-limit` | Maximum token rate currently allowed |
 | `x-tokenlimit-remaining` | Remaining token capacity in the current window |
 | `x-ratelimit-limit-dynamic` | Dynamic request-rate allowance when enabled |
@@ -386,7 +389,7 @@ Rate-limit headers returned on serverless responses:
 
 Best practices:
 
-- plan against the latest headers instead of a hard-coded RPM table
+- watch for `429` responses and back off using the `x-ratelimit-reset` value instead of a hard-coded RPM table
 - keep traffic steady instead of bursty
 - use batch inference for high-volume offline jobs
 - for strict capacity or SLA requirements, use provisioned throughput (reserved capacity on supported stock models with a defined throughput and reliability SLA, contact sales) or dedicated endpoints (single-tenant GPUs, self-serve)


### PR DESCRIPTION
Syncs the `together-chat-completions` skill with the rate-limit clarification landed in [togethercomputer/mintlify-docs#1269](https://github.com/togethercomputer/mintlify-docs/pull/1269) (merge commit `5bde72f`).

### Triggering doc file

- `docs/serverless/rate-limits.mdx` — clarifies that `x-ratelimit-reset` (and the other `x-ratelimit-*` / `x-tokenlimit-*` headers) only appear on `429 Too Many Requests` responses. Successful requests come back with no rate-limit headers. The docs also reworded the intro sentence and the inspect-your-limit code sample to reflect this.

### Skill changes

- `references/api-parameters.md` — Rate Limits & Build Tiers section:
  - Rewrite the intro sentence: successful responses do not include rate-limit headers; `429` responses include `x-ratelimit-reset` with the number of seconds to wait before retrying.
  - Retitle the header table intro to "Rate-limit headers only appear on `429 Too Many Requests` responses; successful responses do not include them. Header reference:".
  - Update the `x-ratelimit-reset` row description from "Time until the request window resets" to "Seconds to wait before retrying" to match the doc's wording.
  - Rewrite the misleading "plan against the latest headers instead of a hard-coded RPM table" best-practice bullet to "watch for `429` responses and back off using the `x-ratelimit-reset` value instead of a hard-coded RPM table".

`quick_validate.py skills/together-chat-completions` passes.

### Not synced (deliberately)

- `docs/dedicated-endpoints/adapter.mdx` and `docs/dedicated-endpoints/rollouts.mdx` also changed in mintlify-docs#1269 (SDK `client.beta.models.create` signature flattening, new "Check revision validation" section, `validator-ignore` markers on rollout snippets). These are all v2-surface content and the current-main `together-dedicated-endpoints` skill is entirely v1 (zero mentions of `beta.models`, `revisions`, `REVISION_VALIDATION_STATUS_*`, `validationStatus`). Same v2-surface-addition-without-landing-target pattern as mintlify-docs#1244 / #1251 — logged, no separate PR opened.
- `docs/mixture-of-agents.mdx`, `docs/parallel-workflows.mdx`, and the `scripts/snippets/**` validator changes in mintlify-docs#1269 are unmapped in `.skills/sync-map.yaml`, so no skill is affected.

_Generated by the Sync Skills Cursor Automation. Please review before merging._
