### PR TITLE
DX-596-together-dedicated-containers: sync with mintlify-docs#1123

### DIFF
--- a/skills/together-dedicated-containers/references/jig-cli.md
+++ b/skills/together-dedicated-containers/references/jig-cli.md
@@ -279,6 +279,8 @@ curl https://api.together.ai/v1/deployment-request/my-deployment/health \
 
 Secrets are encrypted environment variables injected at runtime.
 
+A name cannot appear in both `[tool.jig.deploy.environment_variables]` and a secret. `together beta jig deploy` fails and lists each colliding name if the same name is defined in both places. Remove the duplicate from `pyproject.toml` or run `together beta jig secrets unset --name <name>`.
+
 ### jig secrets set
 
 ```shell
@@ -441,6 +443,8 @@ model = load_model(device=device)
 ### `[tool.jig.deploy.environment_variables]`
 
 Runtime environment variables injected into your container. For sensitive values, use secrets instead.
+
+Each name must be unique across `[tool.jig.deploy.environment_variables]` and secrets. `together beta jig deploy` rejects duplicate names.
 
 ```toml
 [tool.jig.deploy.environment_variables]


### PR DESCRIPTION
Sync with togethercomputer/mintlify-docs#1123 — [docs(jig): document env var and secret name collision validation](https://github.com/togethercomputer/mintlify-docs/pull/1123).

Changed docs files that triggered this sync:

- `docs/deployments-jig.mdx`

Skill changes:

- Add a note under `## Secrets Commands` in `together-dedicated-containers/references/jig-cli.md` that a name cannot appear in both `[tool.jig.deploy.environment_variables]` and a secret; `together beta jig deploy` fails and lists each colliding name, and the fix is to remove the duplicate from `pyproject.toml` or run `together beta jig secrets unset --name <name>`.
- Add a matching one-line note under the `[tool.jig.deploy.environment_variables]` config subsection that each name must be unique across env vars and secrets, and `together beta jig deploy` rejects duplicates.

Generated by the Sync Skills Cursor Automation. Please review before merging.
