### PR TITLE
together-audio: correct direct-upload limit to 80 MB

### DIFF
--- a/skills/together-audio/SKILL.md
+++ b/skills/together-audio/SKILL.md
@@ -58,7 +58,7 @@ Use Together AI audio APIs for:
 - REST TTS returns a `BinaryAPIResponse`; call `response.write_to_file(path)` to save it. Do NOT use `stream_to_file` (it does not exist on this object).
 - Streaming TTS (`stream=True`) returns a `Stream` of `AudioSpeechStreamChunk` objects. Iterate chunks, check `chunk.type`, and decode `base64.b64decode(chunk.delta)` for audio data. There is no file-writing helper on the stream object.
 - Use `client.audio.transcriptions.create()` for transcription and `client.audio.translations.create()` for translation.
-- Batch transcription and translation share hard limits: 500 MB direct upload, 1 GB URL-fetch, 4 hours of audio per request. For larger payloads, pass a public HTTPS URL on `file=`; for longer audio, split into ≤ 4 h chunks. See the Limits section of [references/stt-models.md](references/stt-models.md).
+- Batch transcription and translation share hard limits: 80 MB direct upload, 1 GB URL-fetch, 4 hours of audio per request. For larger payloads, pass a public HTTPS URL on `file=`; for longer audio, split into ≤ 4 h chunks. See the Limits section of [references/stt-models.md](references/stt-models.md).
 - Realtime APIs require audio-format discipline; confirm PCM expectations before streaming bytes.
 - Diarization and word timestamps change response shape; code for the richer verbose output explicitly.
 

--- a/skills/together-audio/references/stt-models.md
+++ b/skills/together-audio/references/stt-models.md
@@ -47,12 +47,12 @@ Both `/v1/audio/transcriptions` and `/v1/audio/translations` enforce the same ca
 
 | Limit | Value | Notes |
 |-------|-------|-------|
-| Max file size (direct upload) | 500 MB | Requests above this are rejected at the edge with `HTTP 413 Payload Too Large`. |
+| Max file size (direct upload) | 80 MB | Requests above this are rejected with `HTTP 413` and error type `request_too_large`. |
 | Max file size (URL fetch) | 1 GB | When you submit an HTTPS URL on the `file` field instead of binary, the server downloads up to 1 GB. Larger downloads fail with `400 file_too_large`. |
 | Max audio duration | 4 hours per request | Longer audio is rejected with `400 audio_too_long`. Split into ≤ 4 h segments and submit separately. |
 
 Tips:
-- For payloads larger than 500 MB, host the file at a public HTTPS URL and pass that URL as the `file` field — the 500 MB edge cap only applies to direct uploads.
+- For payloads larger than 80 MB, host the file at a public HTTPS URL and pass that URL as the `file` field — the 80 MB cap only applies to direct uploads.
 - For audio longer than 4 hours, split into ≤ 4 h chunks before submitting.
 - For binary uploads, place the `model` form field **before** the `file` field in the multipart body so the server can route the request without buffering the full audio payload.
 - Real-time/streaming transports are unaffected by these batch upload limits.
@@ -219,7 +219,7 @@ Speaker segment example:
 | `400 file_too_large` | A URL-fetched audio download exceeded the 1 GB server-side cap. | Compress the source, or split into smaller files. |
 | `400 unsupported_format` | The audio container or codec could not be decoded. | Re-encode to a supported format. Run `ffprobe` on the file to confirm it is valid audio. |
 | `400 invalid_params` | Request parameters failed validation. | Check the API reference for the endpoint. |
-| `413 Payload Too Large` | A direct upload exceeded the 500 MB edge limit. | Submit the file via an HTTPS URL on the `file` field instead, or split the file. |
+| `413 request_too_large` | A direct upload exceeded the 80 MB limit. | Submit the file via an HTTPS URL on the `file` field instead, or split the file. |
 | `429` | Rate limit exceeded. | See serverless rate limits. |
 | `500 processing_failed` | Internal decode failure after the file was accepted. | Verify the file is valid audio with `ffprobe`. If it is, contact Together support with the response `id`. |
 


### PR DESCRIPTION
## Summary

The multipart upload cap for `/v1/audio/transcriptions` and `/v1/audio/translations` is 80 MB, not 500 MB (changed June 23, 2026). Updates the limits table, tips, and error table in `references/stt-models.md` and the hard-limits bullet in `SKILL.md`.

Verified live 2026-08-07: an 85 MB upload returns HTTP 413 with error type `request_too_large`. URL-fetch (1 GB) and duration (4 h) caps are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)