### PR TITLE
Route GPU cluster discovery to live pricing

### DIFF
--- a/quality/trigger-evals/together-gpu-clusters.json
+++ b/quality/trigger-evals/together-gpu-clusters.json
@@ -12,6 +12,10 @@
     "should_trigger": true
   },
   {
+    "query": "List current Together AI GPU cluster regions, find the cheapest on-demand option, and show the command without creating it.",
+    "should_trigger": true
+  },
+  {
     "query": "Deploy a supported chat model to a managed dedicated endpoint with no custom runtime.",
     "should_trigger": false
   },

--- a/skills/together-gpu-clusters/SKILL.md
+++ b/skills/together-gpu-clusters/SKILL.md
@@ -35,6 +35,10 @@ Typical fits:
 
 ## Quick Routing
 
+- **Current regions, instance types, pricing, or a non-creating command plan**
+  - Read [references/pricing-and-discovery.md](references/pricing-and-discovery.md)
+  - Query the live regions endpoint, then compare only the matching numeric rates
+    on the official pricing table
 - **Cluster creation, scaling, credentials, deletion**
   - Start with [scripts/manage_cluster.py](scripts/manage_cluster.py) or [scripts/manage_cluster.ts](scripts/manage_cluster.ts)
   - Read [references/api-reference.md](references/api-reference.md)
@@ -63,6 +67,15 @@ Typical fits:
 - Treat storage lifecycle separately from cluster lifecycle; volumes can outlive clusters.
 - When creating a cluster with new shared storage, prefer inline `shared_volume` over creating a volume separately and attaching via `volume_id`. Separately created volumes may land in a different datacenter partition than the cluster, causing a "does not exist in the datacenter" error even when the volume shows as available.
 - GPU stock-outs (409 "Out of stock") are common. Always call `list_regions()` first and be prepared to try multiple regions.
+- The regions response reports supported configurations, not prices or
+  guaranteed stock. Never infer the cheapest GPU from response order or
+  hardware generation; open the [GPU Cluster pricing table](https://www.together.ai/pricing#gpu-clusters)
+  and compare its numeric on-demand rates.
+- GPU clusters have an 8-GPU minimum. For an hourly estimate, multiply the displayed per-GPU-hour rate by at least 8.
+- `ON_DEMAND` has no one-hour duration flag. For a one-hour plan, omit
+  `--duration-days`, create the cluster only when authorized, then delete it
+  after the intended runtime. If the user requests a command without
+  provisioning, print it but do not run it.
 - The API requires `cuda_version` and `nvidia_driver_version` as separate fields in addition to the combined `driver_version` string. Pass them via `extra_body` in the Python SDK.
 - Credentials retrieval is part of provisioning. Do not stop at cluster creation if the user needs to run workloads immediately.
 - Slurm and Kubernetes operational patterns differ materially; read the cluster-management reference before improvising.
@@ -75,6 +88,8 @@ Typical fits:
 - **Operational guide**: [references/cluster-management.md](references/cluster-management.md)
 - **Operational troubleshooting**: [references/cluster-management.md](references/cluster-management.md)
 - **CLI guide**: [references/cli.md](references/cli.md)
+- **Live inventory, pricing, and non-creating plans**:
+  [references/pricing-and-discovery.md](references/pricing-and-discovery.md)
 - **Python cluster management**: [scripts/manage_cluster.py](scripts/manage_cluster.py)
 - **TypeScript cluster management**: [scripts/manage_cluster.ts](scripts/manage_cluster.ts)
 - **Python storage management**: [scripts/manage_storage.py](scripts/manage_storage.py)
@@ -84,5 +99,6 @@ Typical fits:
 - [GPU Clusters Overview](https://docs.together.ai/docs/gpu-clusters-overview)
 - [GPU Clusters Quickstart](https://docs.together.ai/docs/gpu-clusters-quickstart)
 - [Clusters API](https://docs.together.ai/reference/clusters-create)
+- [GPU Cluster Pricing](https://www.together.ai/pricing#gpu-clusters)
 - [Slurm Startup Scripts](https://docs.together.ai/docs/slurm-startup-scripts)
 - [Instant GPU Clusters](https://www.together.ai/instant-gpu-clusters)

--- a/skills/together-gpu-clusters/references/pricing-and-discovery.md
+++ b/skills/together-gpu-clusters/references/pricing-and-discovery.md
@@ -1,0 +1,82 @@
+# Live GPU Cluster Inventory and Pricing
+
+Use this path when the user asks what is available, what is cheapest, or for a
+command they can inspect without creating a cluster.
+
+## Authoritative surfaces
+
+The two required surfaces answer different questions:
+
+1. Query `GET https://api.together.ai/v1/compute/regions` or run
+   `tg beta clusters list-regions --json` for the live region inventory,
+   supported instance types, and compatible CUDA/driver pairs.
+2. Open the [GPU Cluster pricing table](https://www.together.ai/pricing#gpu-clusters)
+   for current on-demand and reserved rates. Prices are per GPU per hour.
+
+The regions response does **not** include pricing or prove that capacity is in
+stock. Do not infer price from GPU generation, response order, or a static
+instance-type list. A create request can still return `409 Out of stock`.
+
+## Read-only inventory
+
+```shell
+tg beta clusters list-regions --json
+```
+
+Or use REST:
+
+```shell
+curl --fail-with-body --silent --show-error \
+  "https://api.together.ai/v1/compute/regions" \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" \
+  | jq -r '.regions[] | [.name, (.supported_instance_types | join(","))] | @tsv'
+```
+
+When reporting current availability, execute one of these read-only lookups and
+list every region and its supported instance types. Use one compatible
+`cuda_version` / `nvidia_driver_version` pair from the selected region in the
+proposed create command.
+
+## Choosing the cheapest live option
+
+1. Collect the unique instance types from the live regions response.
+2. Match those types to the hardware rows in the official pricing table.
+3. Compare numeric **on-demand** rates only. Treat an em dash or “contact us”
+   as no public numeric rate; never invent a number.
+4. Report the selected per-GPU-hour rate and the total hourly cluster cost.
+
+GPU clusters require `num_gpus` to be a multiple of 8, so the smallest cluster
+uses 8 GPUs. The minimum hourly estimate is therefore:
+
+```text
+8 × selected on-demand price per GPU-hour
+```
+
+## A one-hour on-demand plan is create, then delete
+
+`ON_DEMAND` has no duration setting. `--duration-days` applies to reserved
+capacity and must not be added to an on-demand command. “Run for one hour” means
+create the cluster, let it run for the intended period, then delete it.
+
+If the user asks only to show the command, fill the placeholders below from the
+live inventory and print the commands without executing them:
+
+```shell
+tg beta clusters create \
+  --name one-hour-gpu-cluster \
+  --num-gpus 8 \
+  --gpu-type <CHEAPEST_LIVE_GPU_TYPE> \
+  --region <LIVE_REGION_SUPPORTING_THAT_TYPE> \
+  --nvidia-driver-version <LIVE_DRIVER_VERSION> \
+  --cuda-version <LIVE_CUDA_VERSION> \
+  --billing-type ON_DEMAND \
+  --cluster-type KUBERNETES \
+  --non-interactive \
+  --json
+
+# After approximately one hour, delete the ID returned by create:
+tg beta clusters delete <CLUSTER_ID> --non-interactive
+```
+
+There is no cluster-create dry-run flag. A “dry run” in this context means
+rendering a complete command with live values and not invoking it.


### PR DESCRIPTION
## What changed

- Add a focused GPU-cluster discovery reference that separates live inventory from current pricing.
- Route region, instance-type, pricing, and non-creating command questions to that reference from `SKILL.md`.
- Document the 8-GPU minimum and the correct one-hour `ON_DEMAND` semantics: create, then delete; do not use `--duration-days`.
- Add the exact discovery intent to the GPU-clusters trigger eval set.

The skill does not hard-code a region inventory or prices. It requires a live `GET /v1/compute/regions` or `tg beta clusters list-regions --json` lookup, then comparison of matching numeric rates on the [official GPU Cluster pricing table](https://www.together.ai/pricing#gpu-clusters).

## Root cause

In the [problematic skills run](https://together-agent-eval-3wrm5g5p7-together-ai-0f0e15af.vercel.app/s/0d7a1ca4-3fd5-4771-a270-37db6b6f03da), the agent successfully retrieved live regions, but the injected skill contained no pricing source. It left the bundle, found contradictory rates, and speculated about which hardware was cheapest.

## Behavioral evidence

The equivalent candidate was tested in [together-agent-eval#258](https://github.com/togethercomputer/together-agent-eval/pull/258):

- Official skill control: **0/3** strict planning passes.
- Candidate: **3/3** strict planning passes.
- The [candidate full-harness Claude Sonnet cell](https://together-agent-eval-3wrm5g5p7-together-ai-0f0e15af.vercel.app/s/c90ed275-5c9e-42c2-993b-6f3d3c355ba1) passed with a high-confidence audit.
- After eval PR #258 merged, the [exact immutable merged-head production canary](https://together-agent-eval-3wrm5g5p7-together-ai-0f0e15af.vercel.app/s/9844dea9-cd3e-4c1d-8d82-e4a388756b4c) also passed with high confidence.
- The passing run listed all five live regions, selected H100 at $3.99/GPU-hour and $31.92/hour for the 8-GPU minimum, and printed complete create/delete plans.
- The production canary made one read-only regions request and zero resource-creating or inference calls.

This is task-level evidence, not only a static content check: the original source-cell behavior changed from an unsupported pricing guess to a complete, correctly sourced answer.

## Validation

- `python scripts/quick_validate.py skills/together-gpu-clusters` — pass
- `python scripts/quality_check.py` — GPU-clusters passes; one pre-existing warning remains for the unrelated DMI skill's missing trigger file
- `python -m json.tool quality/trigger-evals/together-gpu-clusters.json` — pass
- `git diff --check` — pass

## Scope

This changes only agent guidance, one focused reference, and the matching trigger eval. It does not create GPU clusters or hard-code a region inventory.
