### PR TITLE
docs(together-video): add FLUX 3 to the model reference

### DIFF
--- a/skills/together-video/SKILL.md
+++ b/skills/together-video/SKILL.md
@@ -19,7 +19,7 @@ Use Together AI video APIs for:
 
 - Generate short videos from prompts
 - Animate an existing image
-- Choose among Veo, Sora, Kling, Seedance, PixVerse, Vidu, or other supported models
+- Choose among Veo, Sora, Kling, Seedance, PixVerse, Vidu, FLUX 3, or other supported models
 - Add polling and download logic to a product or script
 
 ## Hand Off To Another Skill

--- a/skills/together-video/references/models.md
+++ b/skills/together-video/references/models.md
@@ -26,6 +26,7 @@
 | Vidu | Vidu Q1 | `vidu/vidu-q1` | 5s | 1920x1080, 1080x1080, 1080x1920 | 24 | First, Last |
 | Wan-AI | Wan 2.2 T2V | `Wan-AI/Wan2.2-T2V-A14B` | - | - | - | Text-to-Video |
 | Wan-AI | Wan 2.2 I2V | `Wan-AI/Wan2.2-I2V-A14B` | - | - | - | Image-to-Video |
+| Black Forest Labs | FLUX 3 | `black-forest-labs/FLUX-3` | 5-20s | 720p, 1080p (`hd`, `fhd`) | 24 | First, Last, storyboard (up to 10) |
 
 ## Seedance Dimensions
 
@@ -45,11 +46,12 @@
 
 | Feature | Models |
 |---------|--------|
-| Audio generation | Veo 3.0 + Audio, Veo 3.0 Fast + Audio |
+| Audio generation | Veo 3.0 + Audio, Veo 3.0 Fast + Audio, FLUX 3 |
 | Reference images | Vidu 2.0 |
-| First + Last keyframe | Veo 2.0, Kling 2.1 Pro, Seedance, PixVerse, Vidu |
+| First + Last keyframe | Veo 2.0, Kling 2.1 Pro, Seedance, PixVerse, Vidu, FLUX 3 |
 | 10 second duration | Hailuo 02 |
-| 1080p output | Veo 3.0, Seedance Pro, PixVerse, Kling 2.1, Vidu Q1, Sora 2 Pro |
+| Up to 20 second duration | FLUX 3 |
+| 1080p output | Veo 3.0, Seedance Pro, PixVerse, Kling 2.1, Vidu Q1, Sora 2 Pro, FLUX 3 |
 | No prompt required | Kling 2.1 Standard/Pro, Kling 1.6 Pro |
 
 ## Prompt Limits


### PR DESCRIPTION
Together serves `black-forest-labs/FLUX-3` and lists it in the serverless model table, but the `together-video` skill's model reference does not include it, so an agent using this skill will not consider it.

Adds FLUX 3 to the model table and to the audio generation, first and last keyframe, and 1080p feature rows, plus a new row for durations beyond 10 seconds. The dimensions column gives both the human-readable resolutions and the `hd` and `fhd` values the API accepts, since the API takes named tiers rather than pixel dimensions.

`python3 scripts/quick_validate.py skills/together-video` reports `OK together-video`, 1 skill validated, 0 errors.
